### PR TITLE
Fix element type on double layers

### DIFF
--- a/src/layers.jl
+++ b/src/layers.jl
@@ -71,6 +71,7 @@ function DoubleLayer!(dl::DoubleLayer{N,D,G,P},body::Union{Body,BodyList},g::Phy
   return dl
 end
 
+# in-place
 function (μ::DoubleLayer{N,D,<:Edges{C}})(u::Nodes{C},p::ScalarData{N}) where {N,D,C}
     product!(μ.Pbuf,p,μ.nds)
     divergence!(u,mul!(μ.Gbuf,μ.H,μ.Pbuf))
@@ -87,10 +88,13 @@ end
 
 
 #(μ::DoubleLayer{N})(p::ScalarData{N}) where {N} = divergence(μ.H*(p∘μ.nds))
-(μ::DoubleLayer{N,D,G})(p::ScalarData{N}) where {N,D,G<:Edges{C,NX,NY}} where {C,NX,NY} = μ(Nodes(C,(NX,NY)),p)
+# out of place
+(μ::DoubleLayer{N,D,G,P})(p::ScalarData{N,DG}) where {N,D,G<:Edges{C,NX,NY},P<:PointData{N,DG1},DG} where {C,NX,NY,DG1} =
+          μ(Nodes(C,(NX,NY),dtype=DG1),p)
 
 #(μ::DoubleLayer{N})(p::VectorData{N}) where {N} = divergence(μ.H*(p*μ.nds+μ.nds*p))
-(μ::DoubleLayer{N,D,G})(p::VectorData{N}) where {N,D,G<:EdgeGradient{C,F,NX,NY}} where {C,F,NX,NY} = μ(Edges(C,(NX,NY)),p)
+(μ::DoubleLayer{N,D,G,P})(p::VectorData{N,DG}) where {N,D,G<:EdgeGradient{C,F,NX,NY},P<:PointData{N,DG1},DG} where {C,F,NX,NY,DG1} =
+          μ(Edges(C,(NX,NY),dtype=DG1),p)
 
 
 function (μ::DoubleLayer{N,D,G,P})(p::Number) where {N,D,G<:GridData,P<:PointData}
@@ -153,12 +157,14 @@ function SingleLayer!(sl::SingleLayer{N,D,G,P},body::Union{Body,BodyList},g::Phy
   return sl
 end
 
+# In place
 function (μ::SingleLayer{N,D,G})(u::G,p::ScalarData{N}) where {N,D,G}
     product!(μ.Pbuf,p,μ.ds)
     mul!(u,μ.H,μ.Pbuf)
     return u
 end
 
+# Out of place
 (μ::SingleLayer{N,D,G})(p::ScalarData{N}) where {N,D,G} = μ(G(),p)
 #(μ::SingleLayer{N})(p::ScalarData{N}) where {N} = μ.H*(p∘μ.ds)
 

--- a/test/layers.jl
+++ b/test/layers.jl
@@ -5,6 +5,8 @@ ylim = (-5.98,5.98)
 g = PhysicalGrid(xlim,ylim,Δx)
 
 w = Nodes(Dual,size(g))
+wc = Nodes(Dual,size(g),dtype=ComplexF64)
+
 dq = Edges(Dual,w)
 oc = similar(w)
 oc .= 1
@@ -43,6 +45,10 @@ Hs = RegularizationMatrix(regop,ϕ,w)
 
   @test dlayer.H == dlayer2.H
 
+  dlayerc = DoubleLayer(body,g,wc)
+
+  @test eltype(dlayerc(1)) == ComplexF64
+
 end
 
 @testset "Single Layer" begin
@@ -72,5 +78,9 @@ end
   @test abs(dot(oc,inner(w),g) - π*radius^2) < 1e-3
 
   outer = ComplementaryMask(inner)
+
+  innerc = Mask(body,g,wc)
+
+  @test eltype(innerc(wc)) == ComplexF64
 
 end


### PR DESCRIPTION
This PR ensures that out-of-place operations of `DoubleLayer` on grid data respect the element type of the `DoubleLayer`.