### PR TITLE
Add surface operators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,15 +6,20 @@ version = "0.1.4"
 
 [deps]
 CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 CartesianGrids = "0.1.7"
+DocStringExtensions = "0.8.4"
 Reexport = "0.2.0, 1.0"
 RigidBodyTools = "0.1.7"
-julia = "1"
+UnPack = "1.0.2"
+julia = "1.4"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 

--- a/Project.toml
+++ b/Project.toml
@@ -22,8 +22,9 @@ UnPack = "1.0.2"
 julia = "1.4"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "LinearAlgebra"]

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -17,7 +17,7 @@ using UnPack
 
 export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
         DoubleLayer!, SingleLayer!, Mask!,
-        SurfaceCache,
+        SurfaceCache,SurfaceScalarCache,SurfaceVectorCache,
         regularize_normal!,normal_interpolate!,
         surface_curl!,surface_divergence!,surface_grad!,
         CLinvCT,GLinvD,nRTRn

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -5,6 +5,7 @@
 module ImmersedLayers
 
 using Reexport
+using DocStringExtensions
 #@reexport using CartesianGrids
 #@reexport using RigidBodyTools
 using CartesianGrids
@@ -12,13 +13,22 @@ using RigidBodyTools
 
 using LinearAlgebra
 
+using UnPack
+
 export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
-        DoubleLayer!, SingleLayer!, Mask!
+        DoubleLayer!, SingleLayer!, Mask!,
+        SurfaceCache,
+        regularize_normal!,normal_interpolate!,
+        surface_curl!,surface_divergence!,surface_grad!,
+        CLinvCT,GLinvD,nRTRn
 
 abstract type LayerType{N} end
 
 include("tools.jl")
+include("cache.jl")
 include("layers.jl")
+include("surface_operators.jl")
+
 
 
 

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,0 +1,65 @@
+"""
+$(TYPEDEF)
+
+Create a cache of operators and storage data for use in surface operations.
+
+## Constructors
+`SurfaceCache(X::VectorData,nrm::VectorData,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,weights=nothing])`
+
+Here, `X` holds the coordinates of surface data and `nrm` holds the corresponding
+surface normals.
+
+The keyword `weights` can be used to set the weights in the regularization operation.
+By default, it sets the regularization and interpolation to be symmetric matrices
+(i.e., interpolation is the adjoint of regularization with respect to an inner product
+  equal to a vector dot product). By using `weights = dsvec`, where `dsvec` is
+  a vector of surface panel areas corresponding to `X` and `nrm`, then the
+  interpolation and regularization are adjoints with respect to inner products
+  based on discretized integrals.
+
+`SurfaceCache(body::Body/BodyList,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,weights=areas(body)])`
+
+Here, the `body` can be of type `Body` or `BodyList`. The same keyword arguments
+apply. However, now the default is `weights = areas(body)`.
+"""
+struct SurfaceCache{N,NT<:VectorData,REGT<:Regularize,RT<:RegularizationMatrix,ET<:InterpolationMatrix,
+                      LT<:CartesianGrids.Laplacian,GVT<:Edges{Primal},GNT<:Nodes{Dual},GCT<:Nodes{Primal},
+                      SVT<:VectorData,SST<:ScalarData}
+    nrm :: NT
+    regop :: REGT
+    R :: RT
+    E :: ET
+    L :: LT
+    gv_cache :: GVT
+    gn_cache :: GNT
+    gc_cache :: GCT
+    sv_cache :: SVT
+    ss_cache :: SST
+end
+
+function SurfaceCache(X::VectorData{N},nrm::VectorData{N},g::PhysicalGrid; ddftype = CartesianGrids.Yang3, weights = nothing) where {N}
+
+   σtmp = ScalarData(X)
+   svtmp = VectorData(X)
+
+   qtmp = Edges(Primal,size(g))
+   wtmp = Nodes(Dual,size(g))
+   ptmp = Nodes(Primal,size(g))
+
+   if isnothing(weights)
+       regop = Regularize(X, cellsize(g), I0=origin(g), ddftype = CartesianGrids.Yang3, issymmetric=true)
+       Rf, _ = RegularizationMatrix(regop, svtmp, qtmp)
+   else
+       regop = Regularize(X, cellsize(g), I0=origin(g), ddftype = CartesianGrids.Yang3, weights=weights)
+       Rf = RegularizationMatrix(regop, svtmp, qtmp)
+   end
+
+   Ef = InterpolationMatrix(regop, qtmp, svtmp)
+
+   L = plan_laplacian(size(wtmp),with_inverse=true)
+   return SurfaceCache{N,typeof(nrm),typeof(regop),typeof(Rf),typeof(Ef),typeof(L),
+                        typeof(qtmp),typeof(wtmp),typeof(ptmp),typeof(svtmp),typeof(σtmp)}(
+                        nrm,regop,Rf,Ef,L,similar(qtmp),similar(wtmp),similar(ptmp),similar(svtmp),similar(σtmp))
+end
+
+@inline SurfaceCache(body::Union{Body,BodyList},g::PhysicalGrid;ddftype = CartesianGrids.Yang3, weights=areas(body).data) = SurfaceCache(VectorData(collect(body)),normals(body),g;ddftype=ddftype,weights=weights)

--- a/src/surface_operators.jl
+++ b/src/surface_operators.jl
@@ -1,0 +1,171 @@
+"""
+    regularize_normal!(q::Edges{Primal},f::ScalarData,cache::SurfaceCache)
+
+The operation ``R_f n\\circ``, which maps scalar surface data `f` (like
+a jump in scalar potential) to grid data `q` (like velocity). This the adjoint
+to `normal_interpolate!`.
+"""
+@inline regularize_normal!(q::Edges{Primal},f::ScalarData,cache::SurfaceCache) = regularize_normal!(q,f,cache.nrm,cache.R,cache.sv_cache)
+
+function regularize_normal!(q::Edges{Primal,NX,NY},f::ScalarData{N},nrm::VectorData{N},Rf::RegularizationMatrix,sv_cache::VectorData{N}) where {NX,NY,N}
+    product!(sv_cache,nrm,f)
+    q .= Rf*sv_cache
+end
+
+"""
+    normal_interpolate!(vn::ScalarData,q::Edges{Primal},cache::SurfaceCache)
+
+The operation ``n \\cdot I_f``, which maps grid data `q` (like velocity) to scalar
+surface data `vn` (like normal component of surface velocity). This is the
+adjoint to `regularize_normal!`.
+"""
+@inline normal_interpolate!(vn::ScalarData,q::Edges{Primal},cache::SurfaceCache) = normal_interpolate!(vn,q,cache.nrm,cache.E,cache.sv_cache)
+
+function normal_interpolate!(vn::ScalarData{N},q::Edges{Primal,NX,NY},nrm::VectorData{N},Ef::InterpolationMatrix,sv_cache::VectorData{N}) where {NX,NY,N}
+    sv_cache .= Ef*q
+    pointwise_dot!(vn,nrm,sv_cache)
+end
+
+"""
+    surface_curl!(w::Nodes{Dual},f::ScalarData,cache::SurfaceCache)
+
+The operation ``C_s^T = C^T R_f n\\circ``, which maps scalar surface data `f` (like
+a jump in scalar potential) to grid data `w` (like vorticity). This is the adjoint
+to ``C_s``, also given by `surface_curl!` (but with arguments switched).
+"""
+@inline surface_curl!(w::Nodes{Dual},f::ScalarData,cache::SurfaceCache) = surface_curl!(w,f,cache.nrm,cache.R,cache.gv_cache,cache.sv_cache)
+
+function surface_curl!(w::Nodes{Dual,NX,NY},f::ScalarData{N},nrm::VectorData{N},Rf::RegularizationMatrix,q_cache::Edges{Primal,NX,NY},sv_cache::VectorData{N}) where {NX,NY,N}
+    regularize_normal!(q_cache,f,nrm,Rf,sv_cache)
+    curl!(w,q_cache)
+end
+
+"""
+    surface_curl!(vn::ScalarData,s::Nodes{Dual},cache::SurfaceCache)
+
+The operation ``C_s = n \\cdot I_f C``, which maps grid data `s` (like
+streamfunction) to scalar surface data `vn` (like normal component of velocity).
+This is the adjoint to ``C_s^T``, also given by `surface_curl!`, but with
+arguments switched.
+"""
+@inline surface_curl!(vn::ScalarData,s::Nodes{Dual},cache::SurfaceCache) = surface_curl!(vn,s,cache.nrm,cache.E,cache.gv_cache,cache.sv_cache)
+
+function surface_curl!(vn::ScalarData{N},s::Nodes{Dual,NX,NY},nrm::VectorData{N},Ef::InterpolationMatrix,q_cache::Edges{Primal,NX,NY},sv_cache::VectorData{N}) where {NX,NY,N}
+    fill!(q_cache,0.0)
+    curl!(q_cache,s)
+    normal_interpolate!(vn,q_cache,nrm,Ef,sv_cache)
+end
+
+
+"""
+    surface_divergence!(Θ::Nodes{Primal},f::ScalarData,cache::SurfaceCache)
+
+The operation ``D_s = D R_f n \\circ``, which maps surface scalar data `f` (like
+jump in scalar potential) to grid data `Θ` (like dilatation, i.e. divergence of velocity).
+"""
+@inline surface_divergence!(θ::Nodes{Primal},f::ScalarData,cache::SurfaceCache) = surface_divergence!(θ,f,cache.nrm,cache.R,cache.gv_cache,cache.sv_cache)
+
+function surface_divergence!(θ::Nodes{Primal,NX,NY},f::ScalarData{N},nrm::VectorData{N},Rf::RegularizationMatrix,q_cache::Edges{Primal,NX,NY},sv_cache::VectorData{N}) where {NX,NY,N}
+    regularize_normal!(q_cache,f,nrm,Rf,sv_cache)
+    divergence!(θ,q_cache)
+end
+
+"""
+    surface_grad!(vn::ScalarData,ϕ::Nodes{Primal},cache::SurfaceCache)
+
+The operation ``G_s = n \\cdot I_f G``, which maps grid data `ϕ` (like
+scalar potential) to scalar surface data (like normal component of velocity).
+"""
+@inline surface_grad!(vn::ScalarData,ϕ::Nodes{Primal},cache::SurfaceCache) = surface_grad!(vn,ϕ,cache.nrm,cache.E,cache.gv_cache,cache.sv_cache)
+
+function surface_grad!(vn::ScalarData{N},ϕ::Nodes{Primal,NX,NY},nrm::VectorData{N},Ef::InterpolationMatrix,q_cache::Edges{Primal,NX,NY},sv_cache::VectorData{N}) where {NX,NY,N}
+    fill!(q_cache,0.0)
+    grad!(q_cache,ϕ)
+    normal_interpolate!(vn,q_cache,nrm,Ef,sv_cache)
+end
+
+
+"""
+    CLinvCT(cache::SurfaceCache[;scale=1.0])
+
+Construct the square matrix ``-C_s L^{-1}C_s^T``, which maps data of type `ScalarData`
+to data of the same type. The operators `C_s` and `C_s^T` correspond to `surface_curl!`
+and `L` is the grid Laplacian.
+"""
+function CLinvCT(cache::SurfaceCache{N};scale=1.0) where {N}
+    @unpack L, ss_cache, gn_cache = cache
+
+    A = Matrix{Float64}(undef,N,N)
+    fill!(ss_cache,0.0)
+
+    for col in 1:N
+        ss_cache[col] = 1.0
+        fill!(gn_cache,0.0)
+        surface_curl!(gn_cache,ss_cache,cache)
+
+        gn_cache .= -(L\gn_cache);
+        surface_curl!(ss_cache,gn_cache,cache)
+
+        A[:,col] = scale*ss_cache
+        fill!(ss_cache,0.0)
+    end
+
+    return A
+
+end
+
+"""
+    GLinvD(cache::SurfaceCache[;scale=1.0])
+
+Construct the square matrix ``G_s L^{-1}D_s``, which maps data of type `ScalarData`
+to data of the same type. The operators `G_s` and `D_s` correspond to `surface_grad!`
+and `surface_divergence!`, and `L` is the grid Laplacian.
+"""
+function GLinvD(cache::SurfaceCache{N};scale=1.0) where {N}
+    @unpack L, ss_cache, gc_cache = cache
+
+    A = Matrix{Float64}(undef,N,N)
+    fill!(ss_cache,0.0)
+
+    for col in 1:N
+        ss_cache[col] = 1.0
+        fill!(gc_cache,0.0)
+        surface_divergence!(gc_cache,ss_cache,cache)
+
+        gc_cache .= L\gc_cache;
+        surface_grad!(ss_cache,gc_cache,cache)
+
+        A[:,col] = scale*ss_cache
+        fill!(ss_cache,0.0)
+    end
+
+    return A
+
+end
+
+"""
+    nRTRn(cache::SurfaceCache[;scale=1.0])
+
+Construct the square matrix ``n\\cdot I_f R_f n \\circ``, which maps data of type `ScalarData`
+to data of the same type. The operators `I_f` and `R_f` correspond to the interpolation
+and regularization matrices.
+"""
+function nRTRn(cache::SurfaceCache{N};scale=1.0) where {N}
+    @unpack ss_cache, gv_cache = cache
+
+    A = Matrix{Float64}(undef,N,N)
+    fill!(ss_cache,0.0)
+
+    for col in 1:N
+        ss_cache[col] = 1.0
+        fill!(gv_cache,0.0)
+        regularize_normal!(gv_cache,ss_cache,cache)
+        normal_interpolate!(ss_cache,gv_cache,cache)
+
+        A[:,col] = scale*ss_cache
+        fill!(ss_cache,0.0)
+    end
+
+    return A
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
 #@test isempty(detect_ambiguities(ViscousFlow))
 include("tools.jl")
 include("layers.jl")
+include("surface_ops.jl")
 
 
 #@testset ExtendedTestSet "All tests" begin

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -1,0 +1,63 @@
+using LinearAlgebra
+
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+
+RadC = Lx/4
+Δs = 1.4*cellsize(g)
+body = Circle(RadC,Δs)
+X = VectorData(collect(body))
+
+w = Nodes(Dual,size(g))
+ϕ = Nodes(Primal,size(g))
+q = Edges(Primal,size(g))
+f = ScalarData(X)
+
+angs(n) = range(0,2π,length=n+1)[1:n]
+
+@testset "Scalar surface ops" begin
+  scache = SurfaceScalarCache(body,g)
+
+  f .= sin.(angs(length(body)) .- π/4)
+  regularize_normal!(q,f,scache)
+  normal_interpolate!(f,q,scache)
+  @test maximum(f) ≈ 45 atol = 1e-0
+  @test minimum(f) ≈ -45 atol = 1e-0
+
+  A = CLinvCT(scache,scale=cellsize(g))
+
+  @test maximum(eigvals(A)) ≈ 0.2 atol = 1e-1
+  @test minimum(eigvals(A)) > 0
+
+  A = GLinvD(scache,scale=cellsize(g))
+  @test maximum(eigvals(A)) ≈ 0.45 atol = 1e-1
+
+  A = nRTRn(scache)
+  @test maximum(eigvals(A)) ≈ 29 atol = 1e-0
+
+end
+
+dq = EdgeGradient(Primal,size(g))
+vs = VectorData(X)
+
+@testset "Vector surface ops" begin
+  vcache = SurfaceVectorCache(body,g)
+
+  vs.u .= sin.(angs(length(body)) .- π/4)
+
+  regularize_normal!(dq,vs,vcache)
+  normal_interpolate!(vs,dq,vcache)
+  @test minimum(vs.u) ≈ -155 atol = 1e-0
+  @test maximum(vs.u) ≈ 155 atol = 1e-0
+
+  surface_divergence!(q,vs,vcache)
+  surface_grad!(vs,q,vcache)
+
+  A = GLinvD(vcache,scale=cellsize(g))
+  @test maximum(eigvals(A)) ≈ 1.8 atol = 1e-1
+
+
+end

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -36,7 +36,7 @@ angs(n) = range(0,2π,length=n+1)[1:n]
   @test maximum(eigvals(A)) ≈ 0.45 atol = 1e-1
 
   A = nRTRn(scache)
-  @test maximum(eigvals(A)) ≈ 29 atol = 1e-0
+  @test maximum(eigvals(A)) ≈ 45 atol = 1e-0
 
 end
 


### PR DESCRIPTION
This PR extends the notion of layers to more general surface operators like  C^T R n  (curl of a regularized surface field), in addition to D R n (div of a regularized surface field) -- the original `DoubleLayer`. It also provides exact transposes of the surface operators, as well as some useful Schur complement matrices that arise naturally.

It also provides a general cache with all of the necessary intermediate data structures. For now, `SingleLayer` and `DoubleLayer` are left in, but should be removed eventually.

