### PR TITLE
Exporting CartesianGrids.jl and RigidBodyTools.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,8 +27,9 @@ julia = "1.4"
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "LinearAlgebra", "Literate"]
+test = ["Test", "Random", "LinearAlgebra", "Literate", "Plots"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,9 @@ So standard partial differential equations can be adapted for the masked fields,
 
 $$\delta^T(\chi) f = f_s$$
 
-In a computational environment, we discretize the fields on both the surface as well as in the higher-dimensional space, so this immersion process involves *regularization* (the discrete form of immersion) and *interpolation* (the discrete form of restriction), defined with the help of a discrete version of the Dirac delta function, the "DDF". We discretize the higher-dimensional space with the a staggered Cartesian grid, using tools in the `CartesianGrids.jl` package.
+In a computational environment, we discretize the fields on both the surface as well as in the higher-dimensional space, so this immersion process involves *regularization* (the discrete form of immersion) and *interpolation* (the discrete form of restriction), defined with the help of a discrete version of the Dirac delta function, the "DDF". We discretize the higher-dimensional space with the a staggered Cartesian grid, using tools in the `CartesianGrids.jl` package, which is
+fully exported by this package. The package also exports `RigidBodyTools.jl`,
+which has a variety of tools for creating and transforming bodies.
 
 For example, to regularize surface scalar data to the cell centers of the grid,
 we use a matrix operator, $R_c$. Alternatively, for regularizing vector surface data to cell faces, we use $R_f$. Each of these has a transpose, used for interpolation of the grid data to the surface points, e.g, $R_c^T$.

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -16,8 +16,6 @@ operators. The starting point for a cache is the specification of the
 
 ````@example caches
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using LinearAlgebra
 using Plots
 ````
@@ -31,7 +29,7 @@ constructor of the `CartesianGrids.jl` package to create this.
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 ````
 
 ### Set the shape
@@ -43,7 +41,7 @@ is generally best to set it to a value between 1 and 2.
 
 ````@example caches
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
 ````
 
@@ -82,7 +80,7 @@ other choices, such as `CartesianGrids.Roma`, `CartesianGrids.Goza`, `CartesianG
 `CartesianGrids.M3`, `CartesianGrids.M4prime`.
 
 ````@example caches
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling)
+cache = SurfaceScalarCache(body,g,scaling=GridScaling)
 ````
 
 ## Some basic utilities

--- a/docs/src/manual/dirichlet.md
+++ b/docs/src/manual/dirichlet.md
@@ -48,8 +48,6 @@ We will demonstrate these steps here.
 
 ````@example dirichlet
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using LinearAlgebra
 ````
@@ -62,11 +60,11 @@ We do this just as we did in [Immersed layer caches](@ref)
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling);
+cache = SurfaceScalarCache(body,g,scaling=GridScaling);
 nothing #hide
 ````
 

--- a/docs/src/manual/gridops.md
+++ b/docs/src/manual/gridops.md
@@ -26,7 +26,7 @@ using Plots
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 ````
 
 We still generate a cache for these operations, but
@@ -34,7 +34,7 @@ now, we only supply the grid. There are no immersed surfaces
 for this demonstration.
 
 ````@example gridops
-cache = SurfaceScalarCache(grid,scaling=GridScaling)
+cache = SurfaceScalarCache(g,scaling=GridScaling)
 ````
 
 To demonstrate, let's generate a Gaussian

--- a/docs/src/manual/problems.md
+++ b/docs/src/manual/problems.md
@@ -33,8 +33,6 @@ type called `DirichletPoissonProblem`, which we make a subtype of
 
 ````@example problems
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using UnPack
 ````
@@ -118,9 +116,9 @@ now we don't create a cache, since it will be done internally.
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
 ````
 
@@ -133,7 +131,7 @@ Also, note that pretty much any function that accepts `base_cache`
 as an argument also accepts `sys`.
 
 ````@example problems
-prob = DirichletPoissonProblem(grid,body,scaling=GridScaling)
+prob = DirichletPoissonProblem(g,body,scaling=GridScaling)
 sys = ImmersedLayers.__init(prob)
 
 pts = points(sys)

--- a/docs/src/manual/surfaceops.md
+++ b/docs/src/manual/surfaceops.md
@@ -13,8 +13,6 @@ We will start by generating the cache, just as we did in [Immersed layer caches]
 
 ````@example surfaceops
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using LinearAlgebra
 ````
@@ -27,11 +25,11 @@ We do this just as we did in [Immersed layer caches](@ref)
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling)
+cache = SurfaceScalarCache(body,g,scaling=GridScaling)
 ````
 
 ## Basic regularization and interpolation
@@ -94,9 +92,10 @@ and set the values of grid data to the $x$ coordinate. We interpolate and plot,
 comparing to the actual $x$ coordinate of the points on the body:
 
 ````@example surfaceops
-x, y = coordinates(oc,grid)
-xg = similar(oc)
-xg .= x
+#x, y = coordinates(oc,g)
+#xg = similar(oc)
+#xg .= x
+xg = x_grid(cache)
 interpolate!(f,xg,cache)
 plot(f,ylim=(-2,2),label="Interpolated from grid",ylabel="x",xlabel="Index")
 plot!(pts.u,label="Actual body coordinate")

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -6,10 +6,10 @@ module ImmersedLayers
 
 using Reexport
 using DocStringExtensions
-#@reexport using CartesianGrids
-#@reexport using RigidBodyTools
-using CartesianGrids
-using RigidBodyTools
+@reexport using CartesianGrids
+@reexport using RigidBodyTools
+#using CartesianGrids
+#using RigidBodyTools
 
 using LinearAlgebra
 

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -14,8 +14,6 @@ operators. The starting point for a cache is the specification of the
 # ## Setting up a cache
 
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using LinearAlgebra
 using Plots
 
@@ -28,7 +26,7 @@ constructor of the `CartesianGrids.jl` package to create this.
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 
 
 #=
@@ -40,7 +38,7 @@ on this shape equal to 1.4 times the grid spacing. This is not critical, but it
 is generally best to set it to a value between 1 and 2.
 =#
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
 
 
@@ -80,7 +78,7 @@ other choices, such as `CartesianGrids.Roma`, `CartesianGrids.Goza`, `CartesianG
 `CartesianGrids.M3`, `CartesianGrids.M4prime`.
 =#
 
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling)
+cache = SurfaceScalarCache(body,g,scaling=GridScaling)
 
 #=
 ## Some basic utilities

--- a/test/literate/dirichlet.jl
+++ b/test/literate/dirichlet.jl
@@ -46,8 +46,6 @@ We will demonstrate these steps here.
 
 
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using LinearAlgebra
 
@@ -59,11 +57,11 @@ We do this just as we did in [Immersed layer caches](@ref)
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling);
+cache = SurfaceScalarCache(body,g,scaling=GridScaling);
 
 #=
 Let's set up the right-hand side values, $D_s d$ and $\overline{f}_b$.

--- a/test/literate/gridops.jl
+++ b/test/literate/gridops.jl
@@ -22,14 +22,14 @@ using Plots
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 
 #=
 We still generate a cache for these operations, but
 now, we only supply the grid. There are no immersed surfaces
 for this demonstration.
 =#
-cache = SurfaceScalarCache(grid,scaling=GridScaling)
+cache = SurfaceScalarCache(g,scaling=GridScaling)
 
 #=
 To demonstrate, let's generate a Gaussian

--- a/test/literate/problems.jl
+++ b/test/literate/problems.jl
@@ -32,8 +32,6 @@ type called `DirichletPoissonProblem`, which we make a subtype of
 =#
 
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using UnPack
 
@@ -113,9 +111,9 @@ now we don't create a cache, since it will be done internally.
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
 
 #=
@@ -127,7 +125,7 @@ We do this in three steps:
 Also, note that pretty much any function that accepts `base_cache`
 as an argument also accepts `sys`.
 =#
-prob = DirichletPoissonProblem(grid,body,scaling=GridScaling)
+prob = DirichletPoissonProblem(g,body,scaling=GridScaling)
 sys = ImmersedLayers.__init(prob)
 
 pts = points(sys)

--- a/test/literate/surfaceops.jl
+++ b/test/literate/surfaceops.jl
@@ -11,8 +11,6 @@ We will start by generating the cache, just as we did in [Immersed layer caches]
 
 
 using ImmersedLayers
-using CartesianGrids
-using RigidBodyTools
 using Plots
 using LinearAlgebra
 
@@ -24,11 +22,11 @@ We do this just as we did in [Immersed layer caches](@ref)
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
 ylim = (-Lx/2,Lx/2)
-grid = PhysicalGrid(xlim,ylim,Δx)
+g = PhysicalGrid(xlim,ylim,Δx)
 RadC = 1.0
-Δs = 1.4*cellsize(grid)
+Δs = 1.4*cellsize(g)
 body = Circle(RadC,Δs)
-cache = SurfaceScalarCache(body,grid,scaling=GridScaling)
+cache = SurfaceScalarCache(body,g,scaling=GridScaling)
 
 #=
 ## Basic regularization and interpolation
@@ -83,9 +81,10 @@ function of `CartesianGrids.jl`, which gets the coordinates of the grid,
 and set the values of grid data to the $x$ coordinate. We interpolate and plot,
 comparing to the actual $x$ coordinate of the points on the body:
 =#
-x, y = coordinates(oc,grid)
-xg = similar(oc)
-xg .= x
+#x, y = coordinates(oc,g)
+#xg = similar(oc)
+#xg .= x
+xg = x_grid(cache)
 interpolate!(f,xg,cache)
 plot(f,ylim=(-2,2),label="Interpolated from grid",ylabel="x",xlabel="Index")
 plot!(pts.u,label="Actual body coordinate")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ if GROUP == "All" || GROUP == "Auxiliary"
   include("surface_ops.jl")
 end
 
-if GROUP == "Literate"
+if GROUP == "All" || GROUP == "Literate"
   for (root, dirs, files) in walkdir(litdir)
     for file in files
       endswith(file,".jl") && @testset "$file" begin include(joinpath(root,file)) end


### PR DESCRIPTION
This PR re-exports these dependencies. It also includes the literate files in the unit testing, which had been accidentally skipped before.