### PR TITLE
Plotting the immersed layer points on contour plots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -17,7 +17,6 @@ operators. The starting point for a cache is the specification of the
 ````@example caches
 using ImmersedLayers
 using LinearAlgebra
-using Plots
 ````
 
 ### Set up a grid

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -89,7 +89,7 @@ package, using a special plot recipe. This accepts all of the
 usual attribute keywords of the basic plot function.
 
 ````@example caches
-plot(points(cache),cache,xlims=(-2,2),ylims=(-2,2))
+plot(cache,xlims=(-2,2),ylims=(-2,2))
 ````
 
 In this plotting demonstration, we have used the `points` function

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -16,6 +16,7 @@ operators. The starting point for a cache is the specification of the
 
 ````@example caches
 using ImmersedLayers
+using Plots
 using LinearAlgebra
 ````
 
@@ -80,6 +81,23 @@ other choices, such as `CartesianGrids.Roma`, `CartesianGrids.Goza`, `CartesianG
 
 ````@example caches
 cache = SurfaceScalarCache(body,g,scaling=GridScaling)
+````
+
+## Plotting the immersed points
+We can plot the immersed points with the `plot` function of the `Plots.jl`
+package, using a special plot recipe. This accepts all of the
+usual attribute keywords of the basic plot function.
+
+````@example caches
+plot(points(cache),cache,xlims=(-2,2),ylims=(-2,2))
+````
+
+In this plotting demonstration, we have used the `points` function
+to obtain the coordinates of the immersed points. Other useful
+utilities are `normals` and `areas`, e.g.
+
+````@example caches
+normals(cache)
 ````
 
 ## Some basic utilities

--- a/docs/src/manual/surfaceops.md
+++ b/docs/src/manual/surfaceops.md
@@ -61,7 +61,9 @@ nothing #hide
 
 Let's plot this to look at it. This also gives us a chance to highlight
 the plot recipe for grid data associated with the cache, which is achieved by
-simply supplying the cache to the `plot` function in `Plots.jl`.
+simply supplying the cache to the `plot` function in `Plots.jl`. By default,
+this plots the immersed points, as well, but this can be suppressed by
+adding the keyword `layers=false`.
 
 ````@example surfaceops
 plot(gx,cache)

--- a/docs/src/manual/surfaceops.md
+++ b/docs/src/manual/surfaceops.md
@@ -124,7 +124,7 @@ plot(dl,cache)
 If the surface data are vectors, $\mathbf{f}$, then this operation is a little
 different:
 
-$$D_s \mathbf{f} = \nabla\cdot \delta(\chi) \left(  \mathbf{n} \mathbf{f} + \mathbf{f} \mathbf{n} \right)
+$$D_s \mathbf{f} = \nabla\cdot \delta(\chi) \left(  \mathbf{n} \mathbf{f} + \mathbf{f} \mathbf{n} \right)$$
 
 This maps $\mathbf{f}$ to a vector field. We use this in conjunction with a cache
 generated with [`SurfaceVectorCache`](@ref).
@@ -143,7 +143,7 @@ The vector field version of this is
 
 $$G_s \mathbf{u} = \mathbf{n}\cdot \delta^{T}(\chi) (\nabla \mathbf{u} + \nabla^{T} \mathbf{u})$$
 
-which maps vector field data $\mathb{u}$ to vector-valued surface data.
+which maps vector field data $\mathbf{u}$ to vector-valued surface data.
 
 ## A curl layer
 We also sometimes need to take the curl of the regularized surface data,
@@ -192,8 +192,8 @@ and [`complementary_mask`](@ref) achieve this
 m = mask(cache)
 cm = complementary_mask(cache)
 plot(
-    surface(m,cache),
-    surface(cm,cache)
+    surface(m,cache,layers=false),
+    surface(cm,cache,layers=false)
     )
 ````
 

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -1,14 +1,46 @@
 using RecipesBase
 using ColorTypes
-using CartesianGrids
-using RigidBodyTools
+#using CartesianGrids
+#using RigidBodyTools
 
 
-@recipe function f(w::T,cache::BasicILMCache) where {T<:GridData}
+@recipe function f(w::T,cache::BasicILMCache; layers=false) where {T<:GridData}
+
+  framestyle --> :frame
+  xlims --> (-Inf,Inf)
+  ylims --> (-Inf,Inf)
+  aspect_ratio := 1
+  legend --> :none
+  grid --> false
+
   @series begin
     trim := 2
     w, cache.g
   end
+
+  if layers
+    pts = points(cache)
+    #x = [pts.u; pts.u[1]]
+    #y = [pts.v; pts.v[1]]
+    x = pts.u
+    y = pts.v
+    @series begin
+      seriestype --> :scatter
+      markersize --> 1
+      markershape --> :circle
+      markercolor --> :black
+      #linecolor --> :black
+      #fillrange --> 0
+      #fillalpha --> 0
+      #fillcolor --> :black
+      x := x
+      y := y
+      ()
+    end
+  end
+
+
+
 end
 
 @recipe function f(w::T,sys::ILMSystem) where {T<:GridData}
@@ -41,3 +73,19 @@ end
     end
 
 end
+
+#=
+@recipe function f(b::Body)
+    x = [b.x; b.x[1]]
+    y = [b.y; b.y[1]]
+    linecolor --> mygreen
+    fillrange --> 0
+    fillcolor --> mygreen
+    aspect_ratio := 1
+    legend := :none
+    grid := false
+    x := x
+    y := y
+    ()
+end
+=#

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -17,9 +17,9 @@ using ColorTypes
   end
 
   if layers
-    pts = points(cache)
+    #pts = points(cache)
     @series begin
-      pts, cache
+      cache
     end
   end
 
@@ -37,20 +37,21 @@ end
     end
 
     if layers
-      pts = points(cache)
+      #pts = points(cache)
       @series begin
-        pts, cache
+        cache
       end
     end
 
 end
 
-@recipe function f(pts::VectorData,cache::BasicILMCache)
+@recipe function f(cache::BasicILMCache)
+  pts = points(cache)
   #x = [pts.u; pts.u[1]]
   #y = [pts.v; pts.v[1]]
-  x = pts.u
-  y = pts.v
-  seriestype --> :scatter
+  x = [pts.u;]
+  y = [pts.v;]
+  seriestype := :scatter
   markersize --> 1
   markershape --> :circle
   markercolor --> :black
@@ -66,6 +67,10 @@ end
   x := x
   y := y
   ()
+end
+
+@recipe function f(sys::ILMSystem)
+    sys.base_cache
 end
 
 @recipe function f(w::T,sys::ILMSystem) where T<:Union{GridData,VectorData}

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -4,7 +4,7 @@ using ColorTypes
 #using RigidBodyTools
 
 
-@recipe function f(w::T,cache::BasicILMCache; layers=false) where {T<:GridData}
+@recipe function f(w::T,cache::BasicILMCache; layers=true) where {T<:GridData}
 
   framestyle --> :frame
   xlims --> (-Inf,Inf)

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -1,7 +1,5 @@
 using RecipesBase
 using ColorTypes
-#using CartesianGrids
-#using RigidBodyTools
 
 
 @recipe function f(w::T,cache::BasicILMCache; layers=true) where {T<:GridData}
@@ -20,37 +18,15 @@ using ColorTypes
 
   if layers
     pts = points(cache)
-    #x = [pts.u; pts.u[1]]
-    #y = [pts.v; pts.v[1]]
-    x = pts.u
-    y = pts.v
     @series begin
-      seriestype --> :scatter
-      markersize --> 1
-      markershape --> :circle
-      markercolor --> :black
-      #linecolor --> :black
-      #fillrange --> 0
-      #fillalpha --> 0
-      #fillcolor --> :black
-      x := x
-      y := y
-      ()
+      pts, cache
     end
   end
 
-
-
 end
 
-@recipe function f(w::T,sys::ILMSystem) where {T<:GridData}
-  @series begin
-    trim := 2
-    w, sys.base_cache
-  end
-end
 
-@recipe function f(w1::T1,w2::T2,cache::BasicILMCache) where {T1<:GridData,T2<:GridData}
+@recipe function f(w1::T1,w2::T2,cache::BasicILMCache; layers=true) where {T1<:GridData,T2<:GridData}
     @series begin
       w1, cache.g
     end
@@ -60,32 +36,42 @@ end
       w2, cache.g
     end
 
+    if layers
+      pts = points(cache)
+      @series begin
+        pts, cache
+      end
+    end
+
+end
+
+@recipe function f(pts::VectorData,cache::BasicILMCache)
+  #x = [pts.u; pts.u[1]]
+  #y = [pts.v; pts.v[1]]
+  x = pts.u
+  y = pts.v
+  seriestype --> :scatter
+  markersize --> 1
+  markershape --> :circle
+  markercolor --> :black
+  xlims --> (-Inf,Inf)
+  ylims --> (-Inf,Inf)
+  aspect_ratio := 1
+  legend --> :none
+  grid --> false
+  #linecolor --> :black
+  #fillrange --> 0
+  #fillalpha --> 0
+  #fillcolor --> :black
+  x := x
+  y := y
+  ()
+end
+
+@recipe function f(w::T,sys::ILMSystem) where T<:Union{GridData,VectorData}
+    w, sys.base_cache
 end
 
 @recipe function f(w1::T1,w2::T2,sys::ILMSystem) where {T1<:GridData,T2<:GridData}
-    @series begin
-      w1, sys.base_cache
-    end
-
-    @series begin
-      linestyle --> :dash
-      w2, sys.base_cache
-    end
-
+    w1, w2, sys.base_cache
 end
-
-#=
-@recipe function f(b::Body)
-    x = [b.x; b.x[1]]
-    y = [b.y; b.y[1]]
-    linecolor --> mygreen
-    fillrange --> 0
-    fillcolor --> mygreen
-    aspect_ratio := 1
-    legend := :none
-    grid := false
-    x := x
-    y := y
-    ()
-end
-=#

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -15,7 +15,6 @@ operators. The starting point for a cache is the specification of the
 
 using ImmersedLayers
 using LinearAlgebra
-using Plots
 
 #=
 ### Set up a grid

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -86,7 +86,7 @@ We can plot the immersed points with the `plot` function of the `Plots.jl`
 package, using a special plot recipe. This accepts all of the
 usual attribute keywords of the basic plot function.
 =#
-plot(points(cache),cache,xlims=(-2,2),ylims=(-2,2))
+plot(cache,xlims=(-2,2),ylims=(-2,2))
 
 #=
 In this plotting demonstration, we have used the `points` function

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -14,6 +14,7 @@ operators. The starting point for a cache is the specification of the
 # ## Setting up a cache
 
 using ImmersedLayers
+using Plots
 using LinearAlgebra
 
 #=
@@ -78,6 +79,21 @@ other choices, such as `CartesianGrids.Roma`, `CartesianGrids.Goza`, `CartesianG
 =#
 
 cache = SurfaceScalarCache(body,g,scaling=GridScaling)
+
+#=
+## Plotting the immersed points
+We can plot the immersed points with the `plot` function of the `Plots.jl`
+package, using a special plot recipe. This accepts all of the
+usual attribute keywords of the basic plot function.
+=#
+plot(points(cache),cache,xlims=(-2,2),ylims=(-2,2))
+
+#=
+In this plotting demonstration, we have used the `points` function
+to obtain the coordinates of the immersed points. Other useful
+utilities are `normals` and `areas`, e.g.
+=#
+normals(cache)
 
 #=
 ## Some basic utilities

--- a/test/literate/surfaceops.jl
+++ b/test/literate/surfaceops.jl
@@ -52,7 +52,9 @@ regularize!(gx,pts.u,cache) #hide
 #=
 Let's plot this to look at it. This also gives us a chance to highlight
 the plot recipe for grid data associated with the cache, which is achieved by
-simply supplying the cache to the `plot` function in `Plots.jl`.
+simply supplying the cache to the `plot` function in `Plots.jl`. By default,
+this plots the immersed points, as well, but this can be suppressed by
+adding the keyword `layers=false`. 
 =#
 plot(gx,cache)
 

--- a/test/literate/surfaceops.jl
+++ b/test/literate/surfaceops.jl
@@ -54,7 +54,7 @@ Let's plot this to look at it. This also gives us a chance to highlight
 the plot recipe for grid data associated with the cache, which is achieved by
 simply supplying the cache to the `plot` function in `Plots.jl`. By default,
 this plots the immersed points, as well, but this can be suppressed by
-adding the keyword `layers=false`. 
+adding the keyword `layers=false`.
 =#
 plot(gx,cache)
 
@@ -112,7 +112,7 @@ plot(dl,cache)
 If the surface data are vectors, $\mathbf{f}$, then this operation is a little
 different:
 
-$$D_s \mathbf{f} = \nabla\cdot \delta(\chi) \left(  \mathbf{n} \mathbf{f} + \mathbf{f} \mathbf{n} \right)
+$$D_s \mathbf{f} = \nabla\cdot \delta(\chi) \left(  \mathbf{n} \mathbf{f} + \mathbf{f} \mathbf{n} \right)$$
 
 This maps $\mathbf{f}$ to a vector field. We use this in conjunction with a cache
 generated with [`SurfaceVectorCache`](@ref).
@@ -133,7 +133,7 @@ The vector field version of this is
 
 $$G_s \mathbf{u} = \mathbf{n}\cdot \delta^{T}(\chi) (\nabla \mathbf{u} + \nabla^{T} \mathbf{u})$$
 
-which maps vector field data $\mathb{u}$ to vector-valued surface data.
+which maps vector field data $\mathbf{u}$ to vector-valued surface data.
 =#
 
 #=
@@ -183,8 +183,8 @@ and [`complementary_mask`](@ref) achieve this
 m = mask(cache)
 cm = complementary_mask(cache)
 plot(
-    surface(m,cache),
-    surface(cm,cache)
+    surface(m,cache,layers=false),
+    surface(cm,cache,layers=false)
     )
 
 #=


### PR DESCRIPTION
This extends the plot recipe for plotting field data so that it now plots the immersed points with the field data. This is suppressed with `layers=false` keyword to plots.