### PR TITLE
Using body lists in cache to partition surface operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.0"
 
 [deps]
 CartesianGrids = "3e975e5d-2cf8-4263-9573-8460aaf534d9"
+CatViews = "81a5f4ea-a946-549a-aa7e-2a7f63a27d31"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -372,6 +372,16 @@ norm(u::PointData{N},cache::BasicILMCache{N,GridScaling}) where {N} = norm(u,cac
 
 norm(u::PointData{N},cache::BasicILMCache{N,IndexScaling}) where {N} = norm(u)
 
+"""
+    norm(u::PointData,cache::BasicILMCache,i::Int)
+
+Calculate the norm of surface point data `u`, using the scaling associated with `cache`,
+for body `i` in the body list of `cache`.
+""" norm(u::PointData,cache::BasicILMCache,i::Int)
+
+norm(u::PointData{N},cache::BasicILMCache{N,GridScaling},i::Int) where {N} = norm(u,cache.ds,cache.bl,i)
+
+norm(u::PointData{N},cache::BasicILMCache{N,IndexScaling},i::Int) where {N} = norm(u,cache.bl,i)
 
 
 for f in [:ScalarData,:VectorData]
@@ -384,3 +394,13 @@ end
 
 Calculate the inner product of surface point data `u1` and `u2`, using the scaling associated with `cache`.
 """ dot(u1::PointData,u2::PointData,cache::BasicILMCache)
+
+"""
+    dot(u1::PointData,u2::PointData,cache::BasicILMCache,i)
+
+Calculate the inner product of surface point data `u1` and `u2` for body
+`i` in the cache `cache`, scaling as appropriate for this cache.
+"""
+dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,GridScaling},i::Int) where {N} = dot(u1,u2,cache.ds,cache.bl,i)
+
+dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,IndexScaling},i::Int) where {N} = dot(u1,u2,cache.bl,i)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -315,6 +315,15 @@ Return the areas (as `ScalarData`) of the surface panels associated with `cache`
 """
 areas(cache::BasicILMCache) = cache.ds
 
+# Integrals
+"""
+    integrate(u::PointData,cache::BasicILMCache)
+
+Calculate the discrete surface integral of `u` on the immersed points in `cache`.
+This uses trapezoidal rule quadrature.
+"""
+@inline integrate(u::PointData,cache::BasicILMCache) = dot(ones_surface(cache),u,cache)
+
 # Extend norms and inner products
 """
     norm(u::GridData,cache::BasicILMCache)

--- a/src/system.jl
+++ b/src/system.jl
@@ -43,3 +43,11 @@ for f in [:zeros_surface,:zeros_grid,:zeros_gridcurl,:zeros_gridgrad,
           :normals,:areas,:points]
    @eval $f(sys::ILMSystem) = $f(sys.base_cache)
 end
+
+for f in [:norm]
+   @eval $f(a,sys::ILMSystem) = $f(a,sys.base_cache)
+end
+
+for f in [:dot]
+   @eval $f(a,b,sys::ILMSystem) = $f(a,b,sys.base_cache)
+end

--- a/src/system.jl
+++ b/src/system.jl
@@ -46,8 +46,11 @@ end
 
 for f in [:norm]
    @eval $f(a,sys::ILMSystem) = $f(a,sys.base_cache)
+   @eval $f(a,sys::ILMSystem,i::Int) = $f(a,sys.base_cache,i)
+
 end
 
 for f in [:dot]
    @eval $f(a,b,sys::ILMSystem) = $f(a,b,sys.base_cache)
+   @eval $f(a,b,sys::ILMSystem,i::Int) = $f(a,b,sys.base_cache,i)
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -1,4 +1,5 @@
 import LinearAlgebra: dot, norm
+import RigidBodyTools: view
 import Base: ones
 export points, normals, areas
 
@@ -34,6 +35,15 @@ associated with `b`.
 areas(b::Union{Body,BodyList}) = ScalarData(dlengthmid(b))
 
 """
+    view(v::VectorData,bl::BodyList,i::Int)
+
+Provide a view of the range of values in `VectorData` `v`, corresponding to the
+points of the body with index `i` in a BodyList `bl`.
+"""
+@inline view(v::VectorData,bl::BodyList,i::Int) = CatView(view(v.u,bl,i),view(v.v,bl,i))
+
+
+"""
     dot(u1::GridData,u2::GridData,g::PhysicalGrid)
 
 Return the inner product between `u1` and `u2` weighted by the volume (area)
@@ -60,14 +70,37 @@ Return the inner product between `u1` and `u2`, weighted by `ds`.
 dot(u1::ScalarData{N},u2::ScalarData{N},ds::ScalarData{N}) where {N} = dot(u1,ds∘u2)
 
 dot(u1::VectorData{N},u2::VectorData{N},ds::ScalarData{N}) where {N} =
-    dot(u1.u,ds∘u2.u) + dot(u1.v,ds∘u2.v)
+    dot(u1.u,u2.u,ds) + dot(u1.v,u2.v,ds)
+
+
+"""
+    dot(u1::PointData,u2::PointData,ds::ScalarData,bl::BodyList,i)
+
+Return the inner product between `u1` and `u2`, weighted by `ds`,
+for only the data associated with body `i` in body list `bl`.
+"""
+dot(u1::ScalarData{N},u2::ScalarData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} =
+    dot(ScalarData(view(u1,bl,i)),ScalarData(view(u2,bl,i)),ScalarData(view(ds,bl,i)))
+
+dot(u1::VectorData{N},u2::VectorData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} =
+    dot(ScalarData(view(u1.u,bl,i)),ScalarData(view(u2.u,bl,i)),ScalarData(view(ds,bl,i))) +
+    dot(ScalarData(view(u1.v,bl,i)),ScalarData(view(u2.v,bl,i)),ScalarData(view(ds,bl,i)))
+
+
 
 """
     norm(u::PointData,ds::ScalarData)
 
 Return the norm of `u`, weighted by `ds`.
 """
-norm(u::PointData{N},ds::ScalarData{N}) where {N} = sqrt(dot(u,ds,u))
+norm(u::PointData{N},ds::ScalarData{N}) where {N} = sqrt(dot(u,u,ds))
+
+"""
+    norm(u::PointData,ds::ScalarData,bl::BodyList,i)
+
+Return the norm of `u`, weighted by `ds`, for body `i` in body list `bl`
+"""
+norm(u::PointData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = sqrt(dot(u,u,ds,bl,i))
 
 """
     ones(u::ScalarData)

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -87,6 +87,13 @@ dot(u1::VectorData{N},u2::VectorData{N},ds::ScalarData{N},bl::BodyList,i::Int) w
     dot(ScalarData(view(u1.v,bl,i)),ScalarData(view(u2.v,bl,i)),ScalarData(view(ds,bl,i)))
 
 
+dot(u1::ScalarData{N},u2::ScalarData{N},bl::BodyList,i::Int) where {N} =
+    dot(ScalarData(view(u1,bl,i)),ScalarData(view(u2,bl,i)))
+
+dot(u1::VectorData{N},u2::VectorData{N},bl::BodyList,i::Int) where {N} =
+    dot(ScalarData(view(u1.u,bl,i)),ScalarData(view(u2.u,bl,i))) +
+    dot(ScalarData(view(u1.v,bl,i)),ScalarData(view(u2.v,bl,i)))
+
 
 """
     norm(u::PointData,ds::ScalarData)
@@ -101,6 +108,9 @@ norm(u::PointData{N},ds::ScalarData{N}) where {N} = sqrt(dot(u,u,ds))
 Return the norm of `u`, weighted by `ds`, for body `i` in body list `bl`
 """
 norm(u::PointData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = sqrt(dot(u,u,ds,bl,i))
+
+norm(u::PointData{N},bl::BodyList,i::Int) where {N} = sqrt(dot(u,u,bl,i))
+
 
 """
     ones(u::ScalarData)

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -134,7 +134,7 @@ y_grid(cache)
 
 
 #=
-## Norms and inner products
+## Using norms and inner products
 It is useful to compute norms and inner products on grid and surface data.
 These tools are easily accessible, e.g., `dot(u,v,cache)` and `norm(u,cache)`,
 and they respect the scaling associated with the cache. For example,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,6 @@ litdir = "./literate"
 
 if GROUP == "All" || GROUP == "Auxiliary"
   include("tools.jl")
-  include("layers.jl")
   include("surface_ops.jl")
 end
 

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -18,6 +18,14 @@ f = ScalarData(X)
 
 angs(n) = range(0,2π,length=n+1)[1:n]
 
+@testset "Forming a cache" begin
+  scache1 = SurfaceScalarCache(body,g,scaling=GridScaling)
+  scache2 = SurfaceScalarCache(X,g,scaling=GridScaling)
+  @test normals(scache1) == normals(scache2)
+  @test areas(scache1) == areas(scache2)
+  @test points(scache1) == points(scache2)
+end
+
 @testset "Scalar surface ops" begin
   scache = SurfaceScalarCache(body,g,scaling=GridScaling)
 

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -40,6 +40,19 @@ os .= 1
 
 end
 
+bl = BodyList()
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+
+@testset "Operations on body lists" begin
+  Xl = points(bl)
+
+  @test dot(Xl.u,Xl.u,areas(bl),bl,1) == dot(Xl.u,Xl.u,areas(bl),bl,2) == dot(X.u,X.u,ds)
+
+  @test dot(Xl,Xl,areas(bl),bl,1) == dot(Xl,Xl,areas(bl),bl,2) == dot(X,X,ds)
+end
+
+
 @testset "Regularization and Interpolation" begin
   reg = Regularize(X,Δx,I0=origin(g),weights=dlengthmid(body),ddftype=CartesianGrids.Yang3)
 


### PR DESCRIPTION
This makes use of the handy view tools for body lists in `RigidBodyTools.jl` to partition operations like `dot` and `norm` on surface data to work on specific bodies.