### PR TITLE
Added surface integration with the integrate function

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "Home" => "index.md",
         "Manual" => ["manual/caches.md",
                      "manual/surfaceops.md",
+                     "manual/multbodies.md",
                      "manual/gridops.md",
                      "manual/matrices.md",
                      "manual/dirichlet.md",

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -146,7 +146,7 @@ x_grid(cache)
 y_grid(cache)
 ````
 
-## Norms and inner products
+## Using norms and inner products
 It is useful to compute norms and inner products on grid and surface data.
 These tools are easily accessible, e.g., `dot(u,v,cache)` and `norm(u,cache)`,
 and they respect the scaling associated with the cache. For example,
@@ -191,13 +191,17 @@ normals(::BasicILMCache)
 points(::BasicILMCache)
 ```
 
-## Inner products and norms
+## Inner products, norms, and integrals
 
 ```@docs
 dot(::GridData,::GridData,::BasicILMCache)
 dot(::PointData,::PointData,::BasicILMCache)
 norm(::GridData,::BasicILMCache)
 norm(::PointData,::BasicILMCache)
+integrate(::ScalarData{N},::BasicILMCache{N}) where {N}
+dot(::PointData,::PointData,::BasicILMCache,::Int)
+norm(::PointData,::BasicILMCache,::Int)
+integrate(::ScalarData{N},::BasicILMCache{N},::Int) where {N}
 ```
 
 [^1]: Yang, X., et al., (2009) "A smoothing technique for discrete delta functions with application to immersed boundary method in moving boundary simulations," J. Comput. Phys., 228, 7821--7836.

--- a/docs/src/manual/multbodies.md
+++ b/docs/src/manual/multbodies.md
@@ -1,0 +1,101 @@
+```@meta
+EditURL = "<unknown>/literate/multbodies.jl"
+```
+
+# Multiple bodies
+
+```@meta
+CurrentModule = ImmersedLayers
+```
+
+Under the hood, the cache uses the concept of a `Body` to perform certain
+calculations, like normal vectors and surface panel areas, which may
+specialize depending on the type of body shape. Most immersed layer
+operations do not depend on whether there is one or more bodies; rather,
+they only depend on the discrete points, and their associated normals and areas.
+However, some post-processing operations, like surface integrals, do
+depend on distinguishing one body from another. For this reason, the
+cache stores points in a `BodyList`, and several operations can exploit this.
+
+````@example multbodies
+using ImmersedLayers
+using Plots
+using LinearAlgebra
+````
+
+For the demonstration, we use the same grid.
+
+````@example multbodies
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+````
+
+We will create a 2 x 2 array of circles, each of radius 0.5, centered at $(1,1)$, $(1,-1)$,
+$(-1,1)$, $(-1,-1)$.
+
+````@example multbodies
+RadC = 0.5
+Δs = 1.4*cellsize(g)
+body = Circle(RadC,Δs)
+````
+
+We set up the body list by pushing copies of the same body onto the list.
+(We use `deepcopy` to ensure that these are copies, rather than pointers
+to the same body.)
+
+````@example multbodies
+bl = BodyList()
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+````
+
+Now we move them into position. We also use a `RigidTransform` for each,
+which we also assemble into a list. (The `!` is for convenience, using Julia
+convention, to remind us that each transform operates in-place on the body.)
+
+````@example multbodies
+t1! = RigidTransform((1.0,1.0),0.0)
+t2! = RigidTransform((1.0,-1.0),0.0)
+t3! = RigidTransform((-1.0,1.0),0.0)
+t4! = RigidTransform((-1.0,-1.0),0.0)
+tl! = RigidTransformList([t1!,t2!,t3!,t4!])
+nothing #hide
+````
+
+Finally, we apply the transform. We can apply the transform list directly
+to the body list:
+
+````@example multbodies
+tl!(bl)
+````
+
+Now we can create the cache, and inspect it by plotting
+
+````@example multbodies
+cache = SurfaceScalarCache(bl,g,scaling=GridScaling)
+plot(cache,xlims=(-2,2),ylims=(-2,2))
+````
+
+We can now perform operations on data that exploit the division into
+distinct bodies. For example, let's compute the integral of $\mathbf{x}\cdot\mathbf{n}$,
+for body 3. For any of the bodies, this integral should be approximately equal to the
+area enclosed by the body (or volume in 3-d), multiplied by 2 (or 3 in 3-d).
+For a circle of radius $1/2$, this area is $\pi/4$, so we expect the result
+to be nearly $\pi/2$. We use the `pointwise_dot` operation in
+`CartesianGrids.jl` to perform the dot product at each point.
+
+````@example multbodies
+pts = points(cache)
+nrm = normals(cache)
+integrate(pointwise_dot(pts,nrm),cache,3)
+````
+
+---
+
+*This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
+

--- a/docs/src/manual/utilities.md
+++ b/docs/src/manual/utilities.md
@@ -15,6 +15,14 @@ norm(::PointData{N},::ScalarData{N}) where {N}
 integrate(::ScalarData{N},::ScalarData{N}) where {N}
 ones(::ScalarData)
 ```
+
+## Surface point utilities on body lists
+
+```@docs
+copyto!(::PointData,::PointData,::BodyList,::Int)
+copyto!(::ScalarData,::AbstractVector,::BodyList,::Int)
+```
+
 ## Grid utilities
 
 ```@docs

--- a/docs/src/manual/utilities.md
+++ b/docs/src/manual/utilities.md
@@ -12,6 +12,7 @@ normals(::Body)
 points(::Body)
 dot(::ScalarData{N},::ScalarData{N},::ScalarData{N}) where {N}
 norm(::PointData{N},::ScalarData{N}) where {N}
+integrate(::ScalarData{N},::ScalarData{N}) where {N}
 ones(::ScalarData)
 ```
 ## Grid utilities

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -332,14 +332,6 @@ Return the areas (as `ScalarData`) of the surface panels associated with `cache`
 """
 areas(cache::BasicILMCache) = cache.ds
 
-# Integrals
-"""
-    integrate(u::PointData,cache::BasicILMCache)
-
-Calculate the discrete surface integral of `u` on the immersed points in `cache`.
-This uses trapezoidal rule quadrature.
-"""
-@inline integrate(u::PointData,cache::BasicILMCache;kwargs...) = dot(ones_surface(cache),u,cache)
 
 # Extend norms and inner products
 """
@@ -404,3 +396,27 @@ Calculate the inner product of surface point data `u1` and `u2` for body
 dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,GridScaling},i::Int) where {N} = dot(u1,u2,cache.ds,cache.bl,i)
 
 dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,IndexScaling},i::Int) where {N} = dot(u1,u2,cache.bl,i)
+
+
+## Integration
+"""
+    integrate(u::ScalarData,cache::BasicILMCache)
+
+Calculate the discrete surface integral of scalar data `u` on the immersed points in `cache`.
+This uses trapezoidal rule quadrature. This operation produces the same effect,
+regardless if `cache` is set up for `GridScaling` or `IndexScaling`. In both
+cases, the surface element areas are used.
+"""
+@inline integrate(u::ScalarData{N},cache::BasicILMCache{N}) where {N} = integrate(u,cache.ds)
+
+
+"""
+    integrate(u::ScalarData,cache::BasicILMCache,i::Int)
+
+Calculate the discrete surface integral of scalar data `u` on the immersed points in `cache`,
+on body `i` in the body list in `cache`.
+This uses trapezoidal rule quadrature. This operation produces the same effect,
+regardless if `cache` is set up for `GridScaling` or `IndexScaling`. In both
+cases, the surface element areas are used.
+"""
+@inline integrate(u::ScalarData{N},cache::BasicILMCache{N},i::Int) where {N} = integrate(u,cache.ds,cache.bl,i)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -392,7 +392,8 @@ Calculate the inner product of surface point data `u1` and `u2`, using the scali
 
 Calculate the inner product of surface point data `u1` and `u2` for body
 `i` in the cache `cache`, scaling as appropriate for this cache.
-"""
+""" dot(u1::PointData,u2::PointData,cache::BasicILMCache,i::Int)
+
 dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,GridScaling},i::Int) where {N} = dot(u1,u2,cache.ds,cache.bl,i)
 
 dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,IndexScaling},i::Int) where {N} = dot(u1,u2,cache.bl,i)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -401,26 +401,28 @@ dot(u1::PointData{N},u2::PointData{N},cache::BasicILMCache{N,IndexScaling},i::In
 
 ## Integration
 """
-    integrate(u::ScalarData,cache::BasicILMCache)
+    integrate(u::PointData,cache::BasicILMCache)
 
-Calculate the discrete surface integral of scalar data `u` on the immersed points in `cache`.
-This uses trapezoidal rule quadrature. This operation produces the same effect,
+Calculate the discrete surface integral of data `u` on the immersed points in `cache`.
+This uses trapezoidal rule quadrature. If `u` is `VectorData`, then this returns a vector of the integrals in
+each coordinate direction. This operation produces the same effect,
 regardless if `cache` is set up for `GridScaling` or `IndexScaling`. In both
 cases, the surface element areas are used.
 """
-@inline integrate(u::ScalarData{N},cache::BasicILMCache{N}) where {N} = integrate(u,cache.ds)
+@inline integrate(u::PointData{N},cache::BasicILMCache{N}) where {N} = integrate(u,cache.ds)
 
 
 """
-    integrate(u::ScalarData,cache::BasicILMCache,i::Int)
+    integrate(u::PointData,cache::BasicILMCache,i::Int)
 
 Calculate the discrete surface integral of scalar data `u` on the immersed points in `cache`,
 on body `i` in the body list in `cache`.
-This uses trapezoidal rule quadrature. This operation produces the same effect,
+This uses trapezoidal rule quadrature. If `u` is `VectorData`, then this returns a vector of the integrals in
+each coordinate direction. This operation produces the same effect,
 regardless if `cache` is set up for `GridScaling` or `IndexScaling`. In both
 cases, the surface element areas are used.
 """
-@inline integrate(u::ScalarData{N},cache::BasicILMCache{N},i::Int) where {N} = integrate(u,cache.ds,cache.bl,i)
+@inline integrate(u::PointData{N},cache::BasicILMCache{N},i::Int) where {N} = integrate(u,cache.ds,cache.bl,i)
 
 
 """

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -421,3 +421,21 @@ regardless if `cache` is set up for `GridScaling` or `IndexScaling`. In both
 cases, the surface element areas are used.
 """
 @inline integrate(u::ScalarData{N},cache::BasicILMCache{N},i::Int) where {N} = integrate(u,cache.ds,cache.bl,i)
+
+
+"""
+    copyto!(u::PointData,v::PointData,cache::BasicILMCache,i::Int)
+
+Copy the data in the elements of `v` associated with body `i` in the body list in `cache` to
+the corresponding elements in `u`. These data must be of the same type (e.g.,
+`ScalarData` or `VectorData`) and have the same length.
+""" copyto!(u::PointData,v::PointData,cache::BasicILMCache,i::Int)
+
+"""
+    copyto!(u::ScalarData,v::AbstractVector,cache::BasicILMCache,i::Int)
+
+Copy the data in `v` to the elements in `u` associated with body `i` in the body list in `cache`.
+`v` must have the same length as this subarray of `u` associated with `i`.
+""" copyto!(u::ScalarData,v::AbstractVector,cache::BasicILMCache,i::Int)
+
+@inline copyto!(u::PointData{N},v,cache::BasicILMCache{N},i::Int) where {N} = copyto!(u,v,cache.bl,i)

--- a/src/system.jl
+++ b/src/system.jl
@@ -50,7 +50,7 @@ for f in [:norm,:integrate]
 
 end
 
-for f in [:dot]
+for f in [:dot,:copyto!]
    @eval $f(a,b,sys::ILMSystem) = $f(a,b,sys.base_cache)
    @eval $f(a,b,sys::ILMSystem,i::Int) = $f(a,b,sys.base_cache,i)
 end

--- a/src/system.jl
+++ b/src/system.jl
@@ -44,7 +44,7 @@ for f in [:zeros_surface,:zeros_grid,:zeros_gridcurl,:zeros_gridgrad,
    @eval $f(sys::ILMSystem) = $f(sys.base_cache)
 end
 
-for f in [:norm]
+for f in [:norm,:integrate]
    @eval $f(a,sys::ILMSystem) = $f(a,sys.base_cache)
    @eval $f(a,sys::ILMSystem,i::Int) = $f(a,sys.base_cache,i)
 

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -78,6 +78,8 @@ function copyto!(u::ScalarData{N},v::AbstractVector,bl::BodyList,i::Int) where {
     return u
 end
 
+### GRID OPERATIONS
+
 
 ## Dot, norm, integrate
 
@@ -99,6 +101,35 @@ Return the norm of `u`, weighted by the volume (area)
 of the cell in grid `g`.
 """
 norm(u::GridData,g::PhysicalGrid) = sqrt(dot(u,u,g))
+
+"""
+    ones(u::ScalarGridData)
+
+Returns `ScalarGridData` of the same type as `u` filled with ones.
+"""
+function ones(u::ScalarGridData)
+  o = similar(u)
+  o .= 1
+  o
+end
+
+"""
+    ones(u::VectorGridData,dim::Int)
+
+Returns `VectorGridData` of the same type as `u`, filled with ones in
+component `dim`.
+"""
+function ones(u::VectorGridData,dim::Integer)
+  o = zero(u)
+  ocomp = getfield(o,dim+1) # offset
+  ocomp .= 1
+  o
+end
+
+
+### POINT OPERATIONS
+
+## Inner products
 
 """
     dot(u1::PointData,u2::PointData,ds::ScalarData)
@@ -133,24 +164,7 @@ dot(u1::VectorData{N},u2::VectorData{N},bl::BodyList,i::Int) where {N} =
     dot(ScalarData(view(u1.u,bl,i)),ScalarData(view(u2.u,bl,i))) +
     dot(ScalarData(view(u1.v,bl,i)),ScalarData(view(u2.v,bl,i)))
 
-
-"""
-    integrate(u::ScalarData,ds::ScalarData)
-
-Calculate the discrete surface integral of scalar data `u`, using the
-surface element areas in `ds`. This uses trapezoidal rule quadrature.
-"""
-integrate(u::ScalarData{N},ds::ScalarData{N}) where {N} = dot(u,ds)
-
-"""
-    integrate(u::ScalarData,ds::ScalarData,bl::BodyList,i::Int)
-
-Calculate the discrete surface integral of scalar data `u`, restricting the
-integral to body `i` in body list `bl`, using the
-surface element areas in `ds`. This uses trapezoidal rule quadrature.
-"""
-integrate(u::ScalarData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = dot(u,ds,bl,i)
-
+## Norms
 
 """
     norm(u::PointData,ds::ScalarData)
@@ -168,6 +182,34 @@ norm(u::PointData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = sqrt(dot
 
 # Extend the norm that does not scale with surface areas.
 norm(u::PointData{N},bl::BodyList,i::Int) where {N} = sqrt(dot(u,u,bl,i))
+
+## Integrals
+
+"""
+    integrate(u::PointData,ds::ScalarData)
+
+Calculate the discrete surface integral of data `u`, using the
+surface element areas in `ds`. This uses trapezoidal rule quadrature.
+If `u` is `VectorData`, then this returns a vector of the integrals in
+each coordinate direction.
+"""
+integrate(u::ScalarData{N},ds::ScalarData{N}) where {N} = dot(u,ds)
+
+integrate(u::VectorData{N},ds::ScalarData{N}) where {N} = [dot(u.u,ds),dot(u.v,ds)]
+
+"""
+    integrate(u::PointData,ds::ScalarData,bl::BodyList,i::Int)
+
+Calculate the discrete surface integral of scalar data `u`, restricting the
+integral to body `i` in body list `bl`, using the
+surface element areas in `ds`. This uses trapezoidal rule quadrature.
+If `u` is `VectorData`, then this returns a vector of the integrals in
+each coordinate direction.
+"""
+integrate(u::ScalarData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = dot(u,ds,bl,i)
+
+integrate(u::VectorData{N},ds::ScalarData{N},bl::BodyList,i::Int) where {N} = [dot(u.u,ds,bl,i); dot(u.v,ds,bl,i)]
+
 
 
 """
@@ -188,30 +230,6 @@ Returns `VectorData` of the same type as `u`, filled with ones in
 component `dim`.
 """
 function ones(u::VectorData{N},dim::Integer) where {N}
-  o = zero(u)
-  ocomp = getfield(o,dim+1) # offset
-  ocomp .= 1
-  o
-end
-
-"""
-    ones(u::ScalarGridData)
-
-Returns `ScalarGridData` of the same type as `u` filled with ones.
-"""
-function ones(u::ScalarGridData)
-  o = similar(u)
-  o .= 1
-  o
-end
-
-"""
-    ones(u::VectorGridData,dim::Int)
-
-Returns `VectorGridData` of the same type as `u`, filled with ones in
-component `dim`.
-"""
-function ones(u::VectorGridData,dim::Integer)
   o = zero(u)
   ocomp = getfield(o,dim+1) # offset
   ocomp .= 1

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -184,6 +184,8 @@ dot(os,os,cache)
 #md # dot(::PointData,::PointData,::BasicILMCache)
 #md # norm(::GridData,::BasicILMCache)
 #md # norm(::PointData,::BasicILMCache)
+#md # dot(::PointData,::PointData,::BasicILMCache,::BodyList,::Int)
+#md # norm(::PointData,::BasicILMCache,::BodyList,::Int)
 #md # ```
 
 

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -80,6 +80,7 @@ other choices, such as `CartesianGrids.Roma`, `CartesianGrids.Goza`, `CartesianG
 
 cache = SurfaceScalarCache(body,g,scaling=GridScaling)
 
+
 #=
 ## Plotting the immersed points
 We can plot the immersed points with the `plot` function of the `Plots.jl`
@@ -177,15 +178,17 @@ dot(os,os,cache)
 #md # points(::BasicILMCache)
 #md # ```
 
-#md # ## Inner products and norms
+#md # ## Inner products, norms, and integrals
 
 #md # ```@docs
 #md # dot(::GridData,::GridData,::BasicILMCache)
 #md # dot(::PointData,::PointData,::BasicILMCache)
 #md # norm(::GridData,::BasicILMCache)
 #md # norm(::PointData,::BasicILMCache)
-#md # dot(::PointData,::PointData,::BasicILMCache,::BodyList,::Int)
-#md # norm(::PointData,::BasicILMCache,::BodyList,::Int)
+#md # integrate(::ScalarData{N},::BasicILMCache{N}) where {N}
+#md # dot(::PointData,::PointData,::BasicILMCache,::Int)
+#md # norm(::PointData,::BasicILMCache,::Int)
+#md # integrate(::ScalarData{N},::BasicILMCache{N},::Int) where {N}
 #md # ```
 
 

--- a/test/literate/multbodies.jl
+++ b/test/literate/multbodies.jl
@@ -6,22 +6,20 @@
 #md # ```
 
 #=
-Under the hood, the cache uses the concept of a `Body` to perform certain
+Under the hood, the cache uses the concept of a `Body` (from the `RigidBodyTools.jl` package)
+to perform certain
 calculations, like normal vectors and surface panel areas, which may
-specialize depending on the type of body shape. Most immersed layer
+specialize depending on the type of body shape. Note that most immersed layer
 operations do not depend on whether there is one or more bodies; rather,
 they only depend on the discrete points, and their associated normals and areas.
 However, some post-processing operations, like surface integrals, do
 depend on distinguishing one body from another. For this reason, the
 cache stores points in a `BodyList`, and several operations can exploit this.
-
-
 =#
 
 
 using ImmersedLayers
 using Plots
-using LinearAlgebra
 
 #=
 For the demonstration, we use the same grid.
@@ -79,6 +77,7 @@ cache = SurfaceScalarCache(bl,g,scaling=GridScaling)
 plot(cache,xlims=(-2,2),ylims=(-2,2))
 
 #=
+## Body-by-body calculations
 We can now perform operations on data that exploit the division into
 distinct bodies. For example, let's compute the integral of $\mathbf{x}\cdot\mathbf{n}$,
 for body 3. For any of the bodies, this integral should be approximately equal to the
@@ -89,10 +88,40 @@ to be nearly $\pi/2$. We use the `pointwise_dot` operation in
 =#
 pts = points(cache)
 nrm = normals(cache)
-integrate(pointwise_dot(pts,nrm),cache,3)
+V3 = integrate(pointwise_dot(pts,nrm),cache,3)
 
 #=
+We can also integrate `VectorData` over individual bodies, and the result
+is simply a vector with the integral in each coordinate direction. Let's
+demonstrate on another geometric integral, this time of $(\mathbf{x}\cdot\mathbf{x})\mathbf{n}$,
+This integral, when divided by the enclosed area (volume) of the body,
+is equal to the centroid of the body. Let's demonstrate on body 3, which
+we expect to be centered at (-1,1)
+=#
+Xc = integrate(pointwise_dot(pts,pts)∘nrm,cache,3)/V3
+
+#=
+Other operations we can perform body-by-body are [`dot`](@ref) and [`norm`](@ref)
+=#
+
+#=
+## Copying data body by body
 It is common that we will want to assign values to surface data, one body
 at a time. For this, we can make use of an extension of the `copyto!` function.
-Let's see some examples.
+Let's see some examples. Suppose we wish to set the value of a surface
+scalar `u` to the $x$ component of the normal vectors for points on body 3, but
+leave the values zero for all other bodies. Then we just do the following:
+=#
+u = zeros_surface(cache)
+copyto!(u,nrm.u,cache,3)
+nothing #hide
+
+#=
+Let's plot the data to verify this worked
+=#
+plot(u)
+
+#=
+It is also possible to use [`copyto!`](@ref) to copy a vector of just the right
+size of the subarray associated with the body.
 =#

--- a/test/literate/multbodies.jl
+++ b/test/literate/multbodies.jl
@@ -90,3 +90,9 @@ to be nearly $\pi/2$. We use the `pointwise_dot` operation in
 pts = points(cache)
 nrm = normals(cache)
 integrate(pointwise_dot(pts,nrm),cache,3)
+
+#=
+It is common that we will want to assign values to surface data, one body
+at a time. For this, we can make use of an extension of the `copyto!` function.
+Let's see some examples.
+=#

--- a/test/literate/multbodies.jl
+++ b/test/literate/multbodies.jl
@@ -1,0 +1,92 @@
+# # Multiple bodies
+
+
+#md # ```@meta
+#md # CurrentModule = ImmersedLayers
+#md # ```
+
+#=
+Under the hood, the cache uses the concept of a `Body` to perform certain
+calculations, like normal vectors and surface panel areas, which may
+specialize depending on the type of body shape. Most immersed layer
+operations do not depend on whether there is one or more bodies; rather,
+they only depend on the discrete points, and their associated normals and areas.
+However, some post-processing operations, like surface integrals, do
+depend on distinguishing one body from another. For this reason, the
+cache stores points in a `BodyList`, and several operations can exploit this.
+
+
+=#
+
+
+using ImmersedLayers
+using Plots
+using LinearAlgebra
+
+#=
+For the demonstration, we use the same grid.
+=#
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+
+
+#=
+We will create a 2 x 2 array of circles, each of radius 0.5, centered at $(1,1)$, $(1,-1)$,
+$(-1,1)$, $(-1,-1)$.
+=#
+RadC = 0.5
+Δs = 1.4*cellsize(g)
+body = Circle(RadC,Δs)
+
+#=
+We set up the body list by pushing copies of the same body onto the list.
+(We use `deepcopy` to ensure that these are copies, rather than pointers
+to the same body.)
+=#
+bl = BodyList()
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+push!(bl,deepcopy(body))
+
+
+#=
+Now we move them into position. We also use a `RigidTransform` for each,
+which we also assemble into a list. (The `!` is for convenience, using Julia
+convention, to remind us that each transform operates in-place on the body.)
+=#
+t1! = RigidTransform((1.0,1.0),0.0)
+t2! = RigidTransform((1.0,-1.0),0.0)
+t3! = RigidTransform((-1.0,1.0),0.0)
+t4! = RigidTransform((-1.0,-1.0),0.0)
+tl! = RigidTransformList([t1!,t2!,t3!,t4!])
+nothing #hide
+
+#=
+Finally, we apply the transform. We can apply the transform list directly
+to the body list:
+=#
+tl!(bl)
+
+#=
+Now we can create the cache, and inspect it by plotting
+=#
+
+cache = SurfaceScalarCache(bl,g,scaling=GridScaling)
+plot(cache,xlims=(-2,2),ylims=(-2,2))
+
+#=
+We can now perform operations on data that exploit the division into
+distinct bodies. For example, let's compute the integral of $\mathbf{x}\cdot\mathbf{n}$,
+for body 3. For any of the bodies, this integral should be approximately equal to the
+area enclosed by the body (or volume in 3-d), multiplied by 2 (or 3 in 3-d).
+For a circle of radius $1/2$, this area is $\pi/4$, so we expect the result
+to be nearly $\pi/2$. We use the `pointwise_dot` operation in
+`CartesianGrids.jl` to perform the dot product at each point.
+=#
+pts = points(cache)
+nrm = normals(cache)
+integrate(pointwise_dot(pts,nrm),cache,3)

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -62,6 +62,31 @@ push!(bl,deepcopy(body))
   @test isapprox(integrate(pointwise_dot(nrm,nrm),areas(bl),bl,1),2π,atol=1e-3)
   @test isapprox(integrate(pointwise_dot(nrm,nrm),areas(bl),bl,2),2π,atol=1e-3)
 
+  fl = ScalarData(Xl)
+  gl = ScalarData(Xl)
+  gl .= rand(length(gl))
+
+  copyto!(fl,gl,bl,2)
+
+  @test iszero(view(fl,bl,1))
+  @test view(fl,bl,2) == view(gl,bl,2)
+
+  # test the version that copies a vector of just the right size
+  fl = ScalarData(Xl)
+  copyto!(fl,view(gl,bl,2),bl,2)
+
+  @test iszero(view(fl,bl,1))
+  @test view(fl,bl,2) == view(gl,bl,2)
+
+  @test_throws AssertionError copyto!(fl,[1.0,2.0,3.0],bl,2)
+
+  fl = VectorData(Xl)
+  gl = VectorData(Xl)
+  gl .= rand(length(gl))
+
+  copyto!(fl,gl,bl,1)
+  @test iszero(view(fl.u,bl,2)) && iszero(view(fl.v,bl,2))
+  @test view(fl,bl,1) == view(gl,bl,1)
 
 
 end

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -38,6 +38,9 @@ os .= 1
 
    @test isapprox(dot(os,os,ds),2π,atol=1e-3)
 
+   nrm = normals(body)
+   @test isapprox(integrate(pointwise_dot(nrm,nrm),areas(body)),2π,atol=1e-3)
+
 end
 
 bl = BodyList()
@@ -50,6 +53,17 @@ push!(bl,deepcopy(body))
   @test dot(Xl.u,Xl.u,areas(bl),bl,1) == dot(Xl.u,Xl.u,areas(bl),bl,2) == dot(X.u,X.u,ds)
 
   @test dot(Xl,Xl,areas(bl),bl,1) == dot(Xl,Xl,areas(bl),bl,2) == dot(X,X,ds)
+
+  @test norm(Xl.u,areas(bl),bl,1) == norm(Xl.u,areas(bl),bl,2) == norm(X.u,ds)
+
+  @test norm(Xl,areas(bl),bl,1) == norm(Xl,areas(bl),bl,2) == norm(X,ds)
+
+  nrm = normals(bl)
+  @test isapprox(integrate(pointwise_dot(nrm,nrm),areas(bl),bl,1),2π,atol=1e-3)
+  @test isapprox(integrate(pointwise_dot(nrm,nrm),areas(bl),bl,2),2π,atol=1e-3)
+
+
+
 end
 
 


### PR DESCRIPTION
This PR introduces surface integrals with the `integrate` function. For example, it is possible to use `integrate(s,sys)` to integrate scalar surface data `s`, using the data contained i system `sys` (or a cache). Also, one cane use `integrate(s,sys,i)` to restrict this integral to body `i`.