### PR TITLE
Vector-valued surface curl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,17 +9,18 @@ makedocs(
     modules = [ImmersedLayers],
     pages = [
         "Home" => "index.md",
-        "Manual" => [#"manual/caches.md",
-                     #"manual/surfaceops.md",
-                     #"manual/multbodies.md",
-                     #"manual/gridops.md",
-                     #"manual/matrices.md",
-                     #"manual/dirichlet.md",
-                     #"manual/problems.md",
-                     #"manual/neumann.md",
-                     "manual/stokes.md"
-                     #"manual/utilities.md"
-                     ]
+        "Manual" => ["manual/caches.md",
+                     "manual/surfaceops.md",
+                     "manual/multbodies.md",
+                     "manual/gridops.md",
+                     "manual/matrices.md",
+                     "manual/dirichlet.md",
+                     "manual/problems.md",
+                     "manual/utilities.md"
+                     ],
+         "Solving PDEs" => ["manual/neumann.md",
+                            "manual/stokes.md"
+                            ]
         #"Internals" => [ "internals/properties.md"]
     ],
     #format = Documenter.HTML(assets = ["assets/custom.css"])

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,15 +9,16 @@ makedocs(
     modules = [ImmersedLayers],
     pages = [
         "Home" => "index.md",
-        "Manual" => ["manual/caches.md",
-                     "manual/surfaceops.md",
-                     "manual/multbodies.md",
-                     "manual/gridops.md",
-                     "manual/matrices.md",
-                     "manual/dirichlet.md",
-                     "manual/problems.md",
-                     "manual/neumann.md",
-                     "manual/utilities.md"
+        "Manual" => [#"manual/caches.md",
+                     #"manual/surfaceops.md",
+                     #"manual/multbodies.md",
+                     #"manual/gridops.md",
+                     #"manual/matrices.md",
+                     #"manual/dirichlet.md",
+                     #"manual/problems.md",
+                     #"manual/neumann.md",
+                     "manual/stokes.md"
+                     #"manual/utilities.md"
                      ]
         #"Internals" => [ "internals/properties.md"]
     ],

--- a/docs/src/manual/matrices.md
+++ b/docs/src/manual/matrices.md
@@ -56,7 +56,9 @@ obtain this matrix with [`create_surface_filter`](@ref).
 ```@docs
 create_RTLinvR
 create_CLinvCT
+create_CL2invCT
 create_GLinvD
+create_GLinvD_cross
 create_nRTRn
 create_surface_filter
 ```

--- a/docs/src/manual/neumann.md
+++ b/docs/src/manual/neumann.md
@@ -123,7 +123,11 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
 
     vn .= 0.5*(vnplus+vnminus)
     dvn .= vnplus - vnminus
+````
 
+Find the potential
+
+````@example neumann
     regularize!(fstar,dvn,base_cache)
     inverse_laplacian!(fstar,base_cache)
 
@@ -134,7 +138,11 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
     surface_divergence!(f,df,base_cache)
     inverse_laplacian!(f,base_cache)
     f .+= fstar
+````
 
+Find the streamfunction
+
+````@example neumann
     surface_curl!(sstar,df,base_cache)
 
     surface_grad_cross!(ds,fstar,base_cache)
@@ -155,6 +163,8 @@ nothing #hide
 Here, we will demonstrate the solution on a circular shape of radius 1,
 with $v_n^+ = n_x$ and $v_n^- = 0$. This is actually the set of conditions
 used to compute the unit scalar potential field (and, as we will see, the added mass) in potential flow.
+
+Set up the grid
 
 ````@example neumann
 Δx = 0.01
@@ -203,7 +213,19 @@ plot(s,sys,layers=true,levels=30,title="ψ"))
 and the Lagrange multiplier field, $[\phi]$, on the surface
 
 ````@example neumann
-plot(ds)
+plot(df)
+````
+
+If, instead, we set the inner boundary condition to $n_x$ and the
+outer to zero, then we get the flow *inside* of a translating circle
+
+````@example neumann
+vnplus = zeros_surface(sys)
+vnminus = zeros_surface(sys)
+vnminus .= nrm.u
+f, df, s, ds = solve(vnplus,vnminus,prob,sys);
+plot(plot(f,sys,layers=true,levels=30,title="ϕ"),
+plot(s,sys,layers=true,levels=30,title="ψ"))
 ````
 
 ## Multiple bodies

--- a/docs/src/manual/neumann.md
+++ b/docs/src/manual/neumann.md
@@ -123,11 +123,8 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
 
     vn .= 0.5*(vnplus+vnminus)
     dvn .= vnplus - vnminus
-````
 
-Find the potential
-
-````@example neumann
+    # Find the potential
     regularize!(fstar,dvn,base_cache)
     inverse_laplacian!(fstar,base_cache)
 
@@ -138,11 +135,8 @@ Find the potential
     surface_divergence!(f,df,base_cache)
     inverse_laplacian!(f,base_cache)
     f .+= fstar
-````
 
-Find the streamfunction
-
-````@example neumann
+    # Find the streamfunction
     surface_curl!(sstar,df,base_cache)
 
     surface_grad_cross!(ds,fstar,base_cache)

--- a/docs/src/manual/stokes.md
+++ b/docs/src/manual/stokes.md
@@ -1,0 +1,201 @@
+```@meta
+EditURL = "<unknown>/literate/stokes.jl"
+```
+
+# Stokes flow
+
+```@meta
+CurrentModule = ImmersedLayers
+```
+
+Here, we'll demonstrate a solution of the Stokes equations,
+with Dirichlet (i.e. no-slip) boundary conditions on a surface.
+The purpose of this case is to demonstrate the use of the tools with
+vector-valued data -- in this case, the fluid velocity field.
+
+The governing equations for this problem can be written as
+
+$$\mu \nabla^2 \omega - \nabla \times (\delta(\chi) \sigma) = \nabla\times \nabla \cdot (\delta(\chi)\mathbf{\Sigma})$$
+$$\delta^T(\chi) \mathbf{v} = \overline{\mathbf{v}}_b$$
+$$\mathbf{v} = \nabla \phi + \nabla\times \psi$$
+
+where $\psi$ and $\phi$ are the solutions of
+
+$$\nabla^2 \psi = -\omega$$
+$$\nabla^2 \phi = \delta(\chi) \mathbf{n}\cdot [\mathbf{v}_b]$$
+
+and $\mathbf{\Sigma} = \mu ([\mathbf{v}_b]\mathbf{n} + \mathbf{n} [\mathbf{v}_b])$ is a surface viscous flux tensor;
+and $[\mathbf{v}_b] = \mathbf{v}_b^+ - \mathbf{v}_b^-$ and $\overline{v}_b = (\mathbf{v}_b^+ + \mathbf{v}_b^-)/2$ are
+the jump and average of the surface velocities on either side of a surface.
+
+We can discretize and combine these equations into a saddle-point form for $\psi$ and $\sigma$:
+
+$$\begin{bmatrix}L^2 & C_s^T \\ C_s & 0 \end{bmatrix}\begin{pmatrix} \psi \\ \sigma \end{pmatrix} = \begin{pmatrix} -C D_s [\mathbf{v}_b]  \\ \overline{v}_b - G_s L^{-1} R \mathbf{n}\cdot [\mathbf{v}_b]  \end{pmatrix}$$
+
+This saddle-point system has a form similar to the one we got
+
+````@example stokes
+using ImmersedLayers
+using Plots
+using LinearAlgebra
+using UnPack
+````
+
+## Set up the extra cache and solve function
+The problem type takes the usual basic form
+
+````@example stokes
+struct StokesFlowProblem{DT,ST} <: ImmersedLayers.AbstractVectorILMProblem{DT,ST}
+   g :: PhysicalGrid
+   bodies :: BodyList
+   StokesFlowProblem(g::PT,bodies::BodyList;ddftype=CartesianGrids.Yang3,scaling=IndexScaling) where {PT} = new{ddftype,scaling}(g,bodies)
+   StokesFlowProblem(g::PT,body::Body;ddftype=CartesianGrids.Yang3,scaling=IndexScaling) where {PT} = new{ddftype,scaling}(g,BodyList([body]))
+end
+````
+
+As with other cases, the extra cache holds additional intermediate data, as well as
+the Schur complement. We don't bother creating a filtering matrix here.
+
+````@example stokes
+struct StokesFlowCache{SMT,RCT,DVT,VNT,ST,VFT,FT} <: AbstractExtraILMCache
+   S :: SMT
+   Rc :: RCT
+   dv :: DVT
+   vb :: DVT
+   vprime :: DVT
+   dvn :: VNT
+   sstar :: ST
+   vϕ :: VFT
+   ϕ :: FT
+end
+
+function ImmersedLayers.prob_cache(prob::StokesFlowProblem,base_cache::BasicILMCache)
+    S = create_CL2invCT(base_cache)
+
+    dv = zeros_surface(base_cache)
+    vb = zeros_surface(base_cache)
+    vprime = zeros_surface(base_cache)
+
+    dvn = ScalarData(dv)
+    sstar = zeros_gridcurl(base_cache)
+    vϕ = zeros_grid(base_cache)
+    ϕ = Nodes(Primal,sstar)
+
+    Rc = RegularizationMatrix(base_cache,dvn,ϕ)
+
+    StokesFlowCache(S,Rc,dv,vb,vprime,dvn,sstar,vϕ,ϕ)
+end
+
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+Δs = 1.4*cellsize(g);
+
+function ImmersedLayers.solve(vsplus,vsminus,prob::StokesFlowProblem,sys::ILMSystem)
+    @unpack extra_cache, base_cache = sys
+    @unpack S, Rc, dv, vb, vprime, sstar, dvn, vϕ, ϕ  = extra_cache
+
+    σ = zeros_surface(sys)
+    s = zeros_gridcurl(sys)
+    v = zeros_grid(sys)
+
+    dv .= vsplus-vsminus
+    vb .= 0.5*(vsplus + vsminus)
+
+    # Compute ψ*
+    surface_divergence!(v,dv,sys)
+    curl!(sstar,v,sys)
+    sstar .*= -1.0
+
+    inverse_laplacian!(sstar,sys)
+    inverse_laplacian!(sstar,sys)
+
+    # Adjustment for jump in normal velocity
+    pointwise_dot!(dvn,nrm,dv)
+    regularize!(ϕ,dvn,Rc)
+    inverse_laplacian!(ϕ,sys)
+    grad!(vϕ,ϕ,sys)
+    interpolate!(vprime,vϕ,sys)
+    vprime .= vb - vprime
+
+    # Compute surface velocity due to ψ*
+    curl!(v,sstar,sys)
+    interpolate!(vb,v,sys)
+
+    # Spurious slip
+    vprime .-= vb
+    σ .= S\vprime
+
+    # Correction streamfunction
+    surface_curl!(s,σ,sys)
+    s .*= -1.0
+    inverse_laplacian!(s,sys)
+    inverse_laplacian!(s,sys)
+
+    # Correct
+    s .+= sstar
+
+    # Assemble the velocity
+    curl!(v,s,sys)
+    v .+= vϕ
+
+    return v, s, σ, vprime
+end
+
+body = Circle(0.5,Δs)
+
+prob = StokesFlowProblem(g,body,scaling=GridScaling)
+
+sys = ImmersedLayers.__init(prob);
+
+pts = points(sys);
+nrm = normals(sys);
+
+vsplus = zeros_surface(sys);
+vsminus = zeros_surface(sys);
+vsplus.u .= -nrm.v;
+vsplus.v .= nrm.u;
+##vsplus.u .= 1.0;
+##vsplus.v .= 0.0;
+
+vsminus.u .= 0.0;
+
+@time v, s, σ, vprime = solve(vsplus,vsminus,prob,sys);
+
+plot(v,sys)
+
+plot(s,sys)
+
+vb = zeros_surface(sys);
+vb .= 0.5*(vsplus + vsminus);
+vs = zeros_surface(sys);
+
+interpolate!(vs,v,sys);
+
+plot(vs)
+
+plot(σ.u)
+
+F = svd(sys.extra_cache.S);
+
+plot(1.0./F.S,yscale=:log10)
+plot!(F.S./(F.S.^2 .+ 1e-6))
+
+σ2 = zeros_surface(sys);
+
+Σ⁺ = Diagonal(F.S./(F.S.^2 .+ 1e-6))
+S⁺ = F.Vt'*Σ⁺*F.U';
+σ2 .= S⁺*vprime;
+
+plot(σ.u)
+plot!(σ2.u)
+
+norm(sys.extra_cache.S*σ2-vprime)
+````
+
+---
+
+*This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
+

--- a/docs/src/manual/stokes.md
+++ b/docs/src/manual/stokes.md
@@ -13,9 +13,10 @@ with Dirichlet (i.e. no-slip) boundary conditions on a surface.
 The purpose of this case is to demonstrate the use of the tools with
 vector-valued data -- in this case, the fluid velocity field.
 
-The governing equations for this problem can be written as
+After taking the curl of the velocity-pressure form of the Stokes equations, the governing
+equations for this problem can be written as
 
-$$\mu \nabla^2 \omega - \nabla \times (\delta(\chi) \sigma) = \nabla\times \nabla \cdot (\delta(\chi)\mathbf{\Sigma})$$
+$$\mu \nabla^2 \omega - \nabla \times (\delta(\chi) \mathbf{\sigma}) = \nabla\times \nabla \cdot (\delta(\chi)\mathbf{\Sigma})$$
 $$\delta^T(\chi) \mathbf{v} = \overline{\mathbf{v}}_b$$
 $$\mathbf{v} = \nabla \phi + \nabla\times \psi$$
 
@@ -25,14 +26,18 @@ $$\nabla^2 \psi = -\omega$$
 $$\nabla^2 \phi = \delta(\chi) \mathbf{n}\cdot [\mathbf{v}_b]$$
 
 and $\mathbf{\Sigma} = \mu ([\mathbf{v}_b]\mathbf{n} + \mathbf{n} [\mathbf{v}_b])$ is a surface viscous flux tensor;
-and $[\mathbf{v}_b] = \mathbf{v}_b^+ - \mathbf{v}_b^-$ and $\overline{v}_b = (\mathbf{v}_b^+ + \mathbf{v}_b^-)/2$ are
+and $[\mathbf{v}_b] = \mathbf{v}_b^+ - \mathbf{v}_b^-$ and $\overline{\mathbf{v}}_b = (\mathbf{v}_b^+ + \mathbf{v}_b^-)/2$ are
 the jump and average of the surface velocities on either side of a surface.
 
 We can discretize and combine these equations into a saddle-point form for $\psi$ and $\sigma$:
 
-$$\begin{bmatrix}L^2 & C_s^T \\ C_s & 0 \end{bmatrix}\begin{pmatrix} \psi \\ \sigma \end{pmatrix} = \begin{pmatrix} -C D_s [\mathbf{v}_b]  \\ \overline{v}_b - G_s L^{-1} R \mathbf{n}\cdot [\mathbf{v}_b]  \end{pmatrix}$$
+$$\begin{bmatrix}L^2 & C_s^T \\ C_s & 0 \end{bmatrix}\begin{pmatrix} \psi \\ \mathbf{\sigma} \end{pmatrix} = \begin{pmatrix} -C D_s [\mathbf{v}_b]  \\ \overline{v}_b - G_s L^{-1} R \mathbf{n}\cdot [\mathbf{v}_b]  \end{pmatrix}$$
 
-This saddle-point system has a form similar to the one we got
+Note that $L^2$ represents the discrete biharmonic operator. (We have absorbed the
+viscosity $\mu$ into the scaling of the problem.)
+
+We can easily break this down into algorithmic form by the same block-LU decomposition
+of other problems. The difference here is that $\mathbf{\sigma}$ is vector-valued.
 
 ````@example stokes
 using ImmersedLayers
@@ -54,11 +59,13 @@ end
 ````
 
 As with other cases, the extra cache holds additional intermediate data, as well as
-the Schur complement. We don't bother creating a filtering matrix here.
+the Schur complement. We need a few more intermediate variable for this problem.
+We'll also construct the filtering matrix for showing the traction field.
 
 ````@example stokes
-struct StokesFlowCache{SMT,RCT,DVT,VNT,ST,VFT,FT} <: AbstractExtraILMCache
+struct StokesFlowCache{SMT,CMT,RCT,DVT,VNT,ST,VFT,FT} <: AbstractExtraILMCache
    S :: SMT
+   C :: CMT
    Rc :: RCT
    dv :: DVT
    vb :: DVT
@@ -68,9 +75,14 @@ struct StokesFlowCache{SMT,RCT,DVT,VNT,ST,VFT,FT} <: AbstractExtraILMCache
    vϕ :: VFT
    ϕ :: FT
 end
+````
 
+Extend the `prob_cache` function to construct the extra cache
+
+````@example stokes
 function ImmersedLayers.prob_cache(prob::StokesFlowProblem,base_cache::BasicILMCache)
     S = create_CL2invCT(base_cache)
+    C = create_surface_filter(base_cache)
 
     dv = zeros_surface(base_cache)
     vb = zeros_surface(base_cache)
@@ -83,19 +95,20 @@ function ImmersedLayers.prob_cache(prob::StokesFlowProblem,base_cache::BasicILMC
 
     Rc = RegularizationMatrix(base_cache,dvn,ϕ)
 
-    StokesFlowCache(S,Rc,dv,vb,vprime,dvn,sstar,vϕ,ϕ)
+    StokesFlowCache(S,C,Rc,dv,vb,vprime,dvn,sstar,vϕ,ϕ)
 end
+````
 
-Δx = 0.01
-Lx = 4.0
-xlim = (-Lx/2,Lx/2)
-ylim = (-Lx/2,Lx/2)
-g = PhysicalGrid(xlim,ylim,Δx)
-Δs = 1.4*cellsize(g);
+And finally, extend the `solve` function to do the actual solving.
+This form takes as input the the external and internal velocities on the
+surface and returns the velocity field, streamfunction field, and surface
+traction
 
+````@example stokes
 function ImmersedLayers.solve(vsplus,vsminus,prob::StokesFlowProblem,sys::ILMSystem)
     @unpack extra_cache, base_cache = sys
-    @unpack S, Rc, dv, vb, vprime, sstar, dvn, vϕ, ϕ  = extra_cache
+    @unpack nrm = base_cache
+    @unpack S, C, Rc, dv, vb, vprime, sstar, dvn, vϕ, ϕ  = extra_cache
 
     σ = zeros_surface(sys)
     s = zeros_gridcurl(sys)
@@ -141,58 +154,93 @@ function ImmersedLayers.solve(vsplus,vsminus,prob::StokesFlowProblem,sys::ILMSys
     curl!(v,s,sys)
     v .+= vϕ
 
-    return v, s, σ, vprime
+    # Filter the traction twice to clean it up a bit
+    σ .= C^2*σ
+
+    return v, s, σ
 end
+````
 
-body = Circle(0.5,Δs)
+## Set up a grid and body
+We'll consider a rectangle here
 
+````@example stokes
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+Δs = 1.4*cellsize(g)
+body = Rectangle(0.5,0.25,Δs,shifted=true)
+````
+
+Set up the problem and the system
+
+````@example stokes
 prob = StokesFlowProblem(g,body,scaling=GridScaling)
+sys = ImmersedLayers.__init(prob)
+````
 
-sys = ImmersedLayers.__init(prob);
+## Solve the problem
+We will consider the flow generated by two basic motions of the body.
+In the first, we will simply translate the body to the right at unit velocity.
+We set the external $x$ velocity to 1 and $y$ velocity to zero. The
+internal velocity we set to zero.
 
-pts = points(sys);
-nrm = normals(sys);
+````@example stokes
+vsplus = zeros_surface(sys)
+vsminus = zeros_surface(sys)
+vsplus.u .= 1.0
+vsplus.v .= 0.0
+nothing #hide
+````
 
-vsplus = zeros_surface(sys);
-vsminus = zeros_surface(sys);
-vsplus.u .= -nrm.v;
-vsplus.v .= nrm.u;
-##vsplus.u .= 1.0;
-##vsplus.v .= 0.0;
+Now solve it (and time it)
 
-vsminus.u .= 0.0;
+````@example stokes
+solve(vsplus,vsminus,prob,sys) #hide
+@time v, s, σ = solve(vsplus,vsminus,prob,sys)
+nothing #hide
+````
 
-@time v, s, σ, vprime = solve(vsplus,vsminus,prob,sys);
+Let's look at the velocity components
 
+````@example stokes
 plot(v,sys)
+````
 
+Note that the velocity is zero inside, as desired. Let's look at the streamlines here
+
+````@example stokes
 plot(s,sys)
+````
 
-vb = zeros_surface(sys);
-vb .= 0.5*(vsplus + vsminus);
-vs = zeros_surface(sys);
+We'll plot the surface traction components, too.
 
-interpolate!(vs,v,sys);
+````@example stokes
+plot(σ.u,label="σx")
+plot!(σ.v,label="σy")
+````
 
-plot(vs)
+Now, let's apply a different motion, where we rotate it counter-clockwise
+at unit angular velocity
 
-plot(σ.u)
+````@example stokes
+pts = points(sys)
+vsplus.u .= -pts.v
+vsplus.v .= pts.u
+nothing #hide
+````
 
-F = svd(sys.extra_cache.S);
+Solve it again and plot the velocity and streamlines
 
-plot(1.0./F.S,yscale=:log10)
-plot!(F.S./(F.S.^2 .+ 1e-6))
+````@example stokes
+v, s, σ = solve(vsplus,vsminus,prob,sys)
+plot(v,sys)
+````
 
-σ2 = zeros_surface(sys);
-
-Σ⁺ = Diagonal(F.S./(F.S.^2 .+ 1e-6))
-S⁺ = F.Vt'*Σ⁺*F.U';
-σ2 .= S⁺*vprime;
-
-plot(σ.u)
-plot!(σ2.u)
-
-norm(sys.extra_cache.S*σ2-vprime)
+````@example stokes
+plot(s,sys)
 ````
 
 ---

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -33,7 +33,7 @@ export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
         surface_curl!,surface_divergence!,surface_grad!,inverse_laplacian!,
         surface_curl_cross!,surface_divergence_cross!,surface_grad_cross!,
         mask,mask!,complementary_mask,complementary_mask!,
-        create_CLinvCT,create_GLinvD,create_nRTRn,create_RTLinvR,
+        create_CLinvCT,create_CL2invCT,create_GLinvD,create_nRTRn,create_RTLinvR,
         create_GLinvD_cross,create_surface_filter,
         solve
 

--- a/src/grid_operators.jl
+++ b/src/grid_operators.jl
@@ -24,7 +24,7 @@ function divergence!(p::Nodes{Primal,NX,NY},q::Edges{Primal,NX,NY},cache::BasicI
     _scale_derivative!(p,cache)
 end
 
-_unscaled_divergence!(p,q,cache::BasicILMCache) = divergence!(p,q)
+_unscaled_divergence!(p,q,cache::BasicILMCache) = (fill!(p,0.0); divergence!(p,q))
 
 """
     grad!(v::Edges{Primal},p::Nodes{Primal},cache::BasicILMCache)
@@ -39,7 +39,7 @@ function grad!(q::Edges{Primal,NX,NY},p::Nodes{Primal,NX,NY},cache::BasicILMCach
     _scale_derivative!(q,cache)
 end
 
-_unscaled_grad!(q,p,cache::BasicILMCache) = grad!(q,p)
+_unscaled_grad!(q,p,cache::BasicILMCache) = (fill!(q,0.0); grad!(q,p))
 
 """
     curl!(v::Edges{Primal},s::Nodes{Dual},cache::BasicILMCache)
@@ -54,7 +54,7 @@ function curl!(q::Edges{Primal,NX,NY},s::Nodes{Dual,NX,NY},cache::BasicILMCache)
     _scale_derivative!(q,cache)
 end
 
-_unscaled_curl!(q::Edges,s::Nodes,cache::BasicILMCache) = curl!(q,s)
+_unscaled_curl!(q::Edges,s::Nodes,cache::BasicILMCache) = (fill!(q,0.0); curl!(q,s))
 
 """
     curl!(w::Nodes{Dual},v::Edges{Primal},cache::BasicILMCache)
@@ -69,7 +69,7 @@ function curl!(w::Nodes{Dual,NX,NY},q::Edges{Primal,NX,NY},cache::BasicILMCache)
     _scale_derivative!(w,cache)
 end
 
-_unscaled_curl!(w::Nodes,q::Edges,cache::BasicILMCache) = curl!(w,q)
+_unscaled_curl!(w::Nodes,q::Edges,cache::BasicILMCache) = (fill!(w,0.0); curl!(w,q))
 
 
 """
@@ -149,6 +149,7 @@ end
 function _unscaled_convective_derivative!(udu::Edges{Primal},u::Edges{Primal},extra_cache::ConvectiveDerivativeCache)
     @unpack vt1_cache, vt2_cache, vt3_cache = extra_cache
 
+    fill!(vt1_cache,0.0)
     grid_interpolate!(vt1_cache,u)
     CartesianGrids.transpose!(vt2_cache,vt1_cache)
     fill!(vt1_cache,0.0)

--- a/src/matrix_operators.jl
+++ b/src/matrix_operators.jl
@@ -195,7 +195,9 @@ function create_surface_filter(cache::BasicILMCache{N,SCA}) where {N,SCA}
     regfilt = _get_regularization(points(cache),areas(cache),g,
                                   _ddf_type(cache),SCA,filter=true)
     Ef = InterpolationMatrix(regfilt,gdata_cache,sdata_cache)
-    C = zeros(N,N)
+    
+    len = length(sdata_cache)
+    C = Matrix{eltype(sdata_cache)}(undef,len,len)
     return mul!(C,Ef,R)
 
 end

--- a/src/matrix_operators.jl
+++ b/src/matrix_operators.jl
@@ -32,8 +32,8 @@ end
 """
     create_CLinvCT(cache::BasicILMCache[;scale=1.0])
 
-Using the provided cache `cache`, construct the square matrix ``-C_s L^{-1}C_s^T``, which maps data of type `ScalarData`
-to data of the same type. The operators `C_s` and `C_s^T` correspond to [`surface_curl!`](@ref)
+Using the provided cache `cache`, construct the square matrix ``-C_s L^{-1}C_s^T``, which maps
+data of the primary point data type of the cache to data of the same type. The operators `C_s` and `C_s^T` correspond to [`surface_curl!`](@ref)
 and `L` is the grid Laplacian. The optional keyword `scale` multiplies the
 matrix by the designated value.
 """
@@ -49,6 +49,39 @@ function create_CLinvCT(cache::BasicILMCache{N};scale=1.0) where {N}
         fill!(gcurl_cache,0.0)
         surface_curl!(gcurl_cache,sdata_cache,cache)
 
+        inverse_laplacian!(gcurl_cache,cache)
+        surface_curl!(sdata_cache,gcurl_cache,cache)
+
+        A[:,col] = -scale*sdata_cache
+        fill!(sdata_cache,0.0)
+    end
+
+    return A
+
+end
+
+"""
+    create_CL2invCT(cache::BasicILMCache[;scale=1.0])
+
+Using the provided cache `cache`, construct the square matrix ``-C_s L^{-2} C_s^T``, which maps
+data of the primary point data type of the cache to data of the same type. The operators `C_s` and `C_s^T` correspond to [`surface_curl!`](@ref)
+and `L` is the grid Laplacian. The optional keyword `scale` multiplies the
+matrix by the designated value.
+"""
+function create_CL2invCT(cache::BasicILMCache{N};scale=1.0) where {N}
+    @unpack L, sdata_cache, gdata_cache, gcurl_cache = cache
+
+    len = length(sdata_cache)
+    A = Matrix{eltype(sdata_cache)}(undef,len,len)
+    fill!(sdata_cache,0.0)
+
+    for col in 1:len
+        sdata_cache[col] = 1.0
+        fill!(gdata_cache,0.0)
+        fill!(gcurl_cache,0.0)
+
+        surface_curl!(gcurl_cache,sdata_cache,cache)
+        inverse_laplacian!(gcurl_cache,cache)
         inverse_laplacian!(gcurl_cache,cache)
         surface_curl!(sdata_cache,gcurl_cache,cache)
 

--- a/src/surface_operators.jl
+++ b/src/surface_operators.jl
@@ -19,7 +19,7 @@ end
     regularize!(v::Edges{Primal},vb::VectorData,cache::BasicILMCache)
     regularize!(v::Edges{Primal},vb::VectorData,sys::ILMSystem)
 
-The operation ``v = R_f v_b``, which regularizes vector surface data `vb`
+The operation ``\\mathbf{v} = R_f \\mathbf{v}_b``, which regularizes vector surface data `vb`
 onto the grid in the form of scalar grid data `v`. This is the adjoint
 to [`interpolate!`](@ref)
 """
@@ -47,7 +47,7 @@ end
     interpolate!(vb::VectorData,v::Edges{Primal},cache::BasicILMCache)
     interpolate!(vb::VectorData,v::Edges{Primal},sys::ILMSystem)
 
-The operation ``v_b = R_c^T v``, which interpolates vector grid data `v`
+The operation ``\\mathbf{v}_b = R_c^T \\mathbf{v}``, which interpolates vector grid data `v`
 onto the surface points in the form of scalar point data `vb`. This is the adjoint
 to [`regularize!`](@ref)
 """
@@ -58,11 +58,11 @@ function interpolate!(vb::VectorData,v::Edges{Primal},Ef::InterpolationMatrix)
 end
 
 """
-    regularize_normal!(q::Edges{Primal},f::ScalarData,cache::BasicILMCache)
-    regularize_normal!(q::Edges{Primal},f::ScalarData,sys::ILMSystem)
+    regularize_normal!(v::Edges{Primal},f::ScalarData,cache::BasicILMCache)
+    regularize_normal!(v::Edges{Primal},f::ScalarData,sys::ILMSystem)
 
-The operation ``q = R_f n\\circ f``, which maps scalar surface data `f` (like
-a jump in scalar potential) to grid data `q` (like velocity). This is the adjoint
+The operation ``\\mathbf{v} = R_f \\mathbf{n}\\circ f``, which maps scalar surface data `f` (like
+a jump in scalar potential) to grid data `v` (like velocity). This is the adjoint
 to [`normal_interpolate!`](@ref).
 """
 @inline regularize_normal!(q::Edges{Primal},f::ScalarData,cache::BasicILMCache) = regularize_normal!(q,f,cache.nrm,cache.Rsn,cache.snorm_cache)
@@ -76,7 +76,7 @@ end
     regularize_normal!(qt::EdgeGradient{Primal},v::VectorData,cache::BasicILMCache)
     regularize_normal!(qt::EdgeGradient{Primal},v::VectorData,sys::ILMSystem)
 
-The operation ``q_t = R_t n\\circ v``, which maps scalar vector data `v` (like
+The operation ``\\mathbf{q}_t = R_t \\mathbf{n}\\circ \\mathbf{v}``, which maps scalar vector data `v` (like
 a jump in velocity) to grid data `qt` (like velocity-normal tensor). This is the adjoint
 to [`normal_interpolate!`](@ref).
 """
@@ -90,12 +90,12 @@ function regularize_normal!(q::EdgeGradient{Primal,Dual,NX,NY},f::VectorData{N},
 end
 
 """
-    regularize_normal_cross!(q::Edges{Primal},f::ScalarData,cache::BasicILMCache)
-    regularize_normal_cross!(q::Edges{Primal},f::ScalarData,sys::ILMSystem)
+    regularize_normal_cross!(v::Edges{Primal},f::ScalarData,cache::BasicILMCache)
+    regularize_normal_cross!(v::Edges{Primal},f::ScalarData,sys::ILMSystem)
 
-The operation ``q = R_f n\\times f e_z``, which maps scalar surface data `f` (like
-a jump in streamfunction, endowed with the out-of-plane unit vector ``e_z``) to grid
-data `q` (like velocity). This is the adjoint to [`normal_cross_interpolate!`](@ref).
+The operation ``\\mathbf{v} = R_f \\mathbf{n}\\times f \\mathbf{e}_z``, which maps scalar surface data `f` (like
+a jump in streamfunction, endowed with the out-of-plane unit vector ``\\mathbf{e}_z``) to grid
+data `v` (like velocity). This is the adjoint to [`normal_cross_interpolate!`](@ref).
 """
 @inline regularize_normal_cross!(q::Edges{Primal},f::ScalarData,cache::BasicILMCache) =
            regularize_normal_cross!(q,f,cache.nrm,cache.Rsn,cache.snorm_cache)
@@ -107,10 +107,10 @@ end
 
 
 """
-    normal_interpolate!(vn::ScalarData,q::Edges{Primal},cache::BasicILMCache)
-    normal_interpolate!(vn::ScalarData,q::Edges{Primal},sys::ILMSystem)
+    normal_interpolate!(vn::ScalarData,v::Edges{Primal},cache::BasicILMCache)
+    normal_interpolate!(vn::ScalarData,v::Edges{Primal},sys::ILMSystem)
 
-The operation ``v_n = n \\cdot R_f^T q``, which maps grid data `q` (like velocity) to scalar
+The operation ``v_n = \\mathbf{n} \\cdot R_f^T \\mathbf{v}``, which maps grid data `v` (like velocity) to scalar
 surface data `vn` (like normal component of surface velocity). This is the
 adjoint to [`regularize_normal!`](@ref).
 """
@@ -125,7 +125,7 @@ end
     normal_interpolate!(τ::VectorData,A::EdgeGradient{Primal},cache::BasicILMCache)
     normal_interpolate!(τ::VectorData,A::EdgeGradient{Primal},sys::ILMSystem)
 
-The operation ``\\tau = n \\cdot R_t^T (A + A^T)``, which maps grid tensor data `A` (like velocity gradient tensor) to vector
+The operation ``\\mathbf{\\tau} = \\mathbf{n} \\cdot R_t^T (\\mathbf{A} +\\mathbf{A}^T)``, which maps grid tensor data `A` (like velocity gradient tensor) to vector
 surface data `τ` (like traction). This is the adjoint to [`regularize_normal!`](@ref).
 """
 @inline normal_interpolate!(vn::VectorData,q::EdgeGradient{Primal},cache::BasicILMCache) = normal_interpolate!(vn,q,cache.nrm,cache.Esn,cache.gsnorm2_cache,cache.snorm_cache)
@@ -138,10 +138,10 @@ function normal_interpolate!(vn::VectorData{N},q::EdgeGradient{Primal,Dual,NX,NY
 end
 
 """
-    normal_cross_interpolate!(wn::ScalarData,q::Edges{Primal},cache::BasicILMCache)
-    normal_cross_interpolate!(wn::ScalarData,q::Edges{Primal},sys::ILMSystem)
+    normal_cross_interpolate!(wn::ScalarData,v::Edges{Primal},cache::BasicILMCache)
+    normal_cross_interpolate!(wn::ScalarData,v::Edges{Primal},sys::ILMSystem)
 
-The operation ``w_n = e_z\\cdot (n \\times R_f^T q)``, which maps grid data `q` (like velocity) to scalar
+The operation ``w_n = e_z\\cdot (\\mathbf{n} \\times R_f^T \\mathbf{v})``, which maps grid data `v` (like velocity) to scalar
 surface data `wn` (like vorticity in the surface). This is the
 adjoint to [`regularize_normal!`](@ref).
 """
@@ -157,7 +157,7 @@ end
     surface_curl!(w::Nodes{Dual},f::ScalarData,cache::BasicILMCache)
     surface_curl!(w::Nodes{Dual},f::ScalarData,sys::ILMSystem)
 
-The operation ``w = C_s^T f = C^T R_f n\\circ f``, which maps scalar surface data `f` (like
+The operation ``w = C_s^T f = C^T R_f \\mathbf{n}\\circ f``, which maps scalar surface data `f` (like
 a jump in scalar potential) to grid data `w` (like vorticity). This is the adjoint
 to ``C_s``, also given by `surface_curl!` (but with arguments switched). Note that
 the differential operations are divided either by 1 or by the grid cell size,
@@ -179,7 +179,7 @@ end
     surface_curl!(w::Nodes{Dual},v::VectorData,cache::BasicILMCache)
     surface_curl!(w::Nodes{Dual},v::VectorData,sys::ILMSystem)
 
-The operation ``w = C_s^T v = C^T R_f v``, which maps vector surface data `v` (like
+The operation ``w = C_s^T \\mathbf{v} = C^T R_f \\mathbf{v}``, which maps vector surface data `v` (like
 velocity) to grid data `w` (like vorticity). This is the adjoint
 to ``C_s``, also given by `surface_curl!` (but with arguments switched). Note that
 the differential operations are divided either by 1 or by the grid cell size,
@@ -201,7 +201,7 @@ end
     surface_curl!(vn::ScalarData,s::Nodes{Dual},cache::BasicILMCache)
     surface_curl!(vn::ScalarData,s::Nodes{Dual},sys::ILMSystem)
 
-The operation ``v_n = C_s s = n \\cdot R_f^T C s``, which maps grid data `s` (like
+The operation ``v_n = C_s s = \\mathbf{n} \\cdot R_f^T C s``, which maps grid data `s` (like
 streamfunction) to scalar surface data `vn` (like normal component of velocity).
 This is the adjoint to ``C_s^T``, also given by `surface_curl!`, but with
 arguments switched.  Note that
@@ -224,8 +224,8 @@ end
     surface_curl!(v::VectorData,s::Nodes{Dual},cache::BasicILMCache)
     surface_curl!(v::VectorData,s::Nodes{Dual},sys::ILMSystem)
 
-The operation ``v = C_s s = R_f^T C s``, which maps grid data `s` (like
-streamfunction) to vector surface data `v` (like normal component of velocity).
+The operation ``\\mathbf{v} = C_s s = R_f^T C s``, which maps grid data `s` (like
+streamfunction) to vector surface data `v` (like velocity).
 This is the adjoint to ``C_s^T``, also given by `surface_curl!`, but with
 arguments switched.  Note that
 the differential operations are divided either by 1 or by the grid cell size,
@@ -249,8 +249,8 @@ end
     surface_curl_cross!(w::Nodes{Dual},f::ScalarData,cache::BasicILMCache)
     surface_curl_cross!(w::Nodes{Dual},f::ScalarData,sys::ILMSystem)
 
-The operation ``w = \\hat{C}_s^T f = C^T R_f n\\times f e_z``, which maps scalar surface data `f` (like
-a jump in streamfunction, multiplied by out-of-plane unit vector ``e_z``) to grid data `w` (like vorticity).
+The operation ``w = \\hat{C}_s^T f = C^T R_f \\mathbf{n}\\times f \\mathbf{e}_z``, which maps scalar surface data `f` (like
+a jump in streamfunction, multiplied by out-of-plane unit vector ``\\mathbf{e}_z``) to grid data `w` (like vorticity).
 This is the adjoint to ``\\hat{C}_s``, also given by `surface_curl_cross!` (but with arguments switched). Note that
 the differential operations are divided either by 1 or by the grid cell size,
 depending on whether `sys` has been designated with `IndexScaling` or `GridScaling`,
@@ -271,7 +271,7 @@ end
     surface_curl_cross!(γ::ScalarData,s::Nodes{Dual},cache::BasicILMCache)
     surface_curl_cross!(γ::ScalarData,s::Nodes{Dual},sys::ILMSystem)
 
-The operation ``\\gamma = \\hat{C}_s s = e_z\\cdot (n \\times R_f^T C s)``, which maps grid data `s` (like
+The operation ``\\gamma = \\hat{C}_s s = \\mathbf{e}_z\\cdot (\\mathbf{n} \\times R_f^T C s)``, which maps grid data `s` (like
 streamfunction) to scalar surface data `γ` (like vorticity in the surface).
 This is the adjoint to ``\\hat{C}_s^T``, also given by `surface_curl_cross!`, but with
 arguments switched.  Note that
@@ -295,7 +295,7 @@ end
     surface_divergence!(Θ::Nodes{Primal},f::ScalarData,cache::BasicILMCache)
     surface_divergence!(Θ::Nodes{Primal},f::ScalarData,sys::ILMSystem)
 
-The operation ``\\theta = D_s f = D R_f n \\circ f``, which maps surface scalar data `f` (like
+The operation ``\\theta = D_s f = D R_f \\mathbf{n} \\circ f``, which maps surface scalar data `f` (like
 jump in scalar potential) to grid data `Θ` (like dilatation, i.e. divergence of velocity).
 This is the adjoint of [`surface_grad!`](@ref).
 Note that
@@ -318,7 +318,7 @@ end
     surface_divergence!(v::Edges{Primal},dv::VectorData,cache::BasicILMCache)
     surface_divergence!(v::Edges{Primal},dv::VectorData,sys::ILMSystem)
 
-The operation ``v = D_s dv = D R_f (n \\circ dv + dv \\circ n)``, which maps surface vector data `dv` (like
+The operation ``\\mathbf{v} = D_s d\\mathbf{v} = D R_f (\\mathbf{n} \\circ d\\mathbf{v} + d\\mathbf{v} \\circ \\mathbf{n})``, which maps surface vector data `dv` (like
 jump in velocity) to grid data `v` (like velocity). This is the adjoint of [`surface_grad!`](@ref). Note that
 the differential operations are divided either by 1 or by the grid cell size,
 depending on whether `sys` has been designated with `IndexScaling` or `GridScaling`,
@@ -339,7 +339,7 @@ end
     surface_grad!(vn::ScalarData,ϕ::Nodes{Primal},cache::BasicILMCache)
     surface_grad!(vn::ScalarData,ϕ::Nodes{Primal},sys::ILMSystem)
 
-The operation ``v_n = G_s\\phi = n \\cdot R_f^T G\\phi``, which maps grid data `ϕ` (like
+The operation ``v_n = G_s\\phi = \\mathbf{n} \\cdot R_f^T G\\phi``, which maps grid data `ϕ` (like
 scalar potential) to scalar surface data `vn` (like normal component of velocity). This is the adjoint of [`surface_divergence!`](@ref).
 Note that
 the differential operations are divided either by 1 or by the grid cell size,
@@ -361,7 +361,7 @@ end
     surface_grad!(τ::VectorData,v::Edges{Primal},cache::BasicILMCache)
     surface_grad!(τ::VectorData,v::Edges{Primal},sys::ILMSystem)
 
-The operation ``\\tau = G_s v = n \\cdot R_t^T (G v + (G v)^T)``, which maps grid vector data `v` (like
+The operation ``\\mathbf{\\tau} = G_s v = \\mathbf{n} \\cdot R_t^T (G \\mathbf{v} + (G \\mathbf{v})^T)``, which maps grid vector data `v` (like
 velocity) to vector surface data `τ` (like traction). This is the adjoint of [`surface_divergence!`](@ref). Note that
 the differential operations are divided either by 1 or by the grid cell size,
 depending on whether `sys` has been designated with `IndexScaling` or `GridScaling`,
@@ -384,7 +384,7 @@ end
     surface_divergence_cross!(Θ::Nodes{Primal},f::ScalarData,cache::BasicILMCache)
     surface_divergence_cross!(Θ::Nodes{Primal},f::ScalarData,sys::ILMSystem)
 
-The operation ``\\theta = \\hat{D}_s f = D R_f n \\times f e_z``, which maps surface scalar data `f` (like
+The operation ``\\theta = \\hat{D}_s f = D R_f \\mathbf{n} \\times f \\mathbf{e}_z``, which maps surface scalar data `f` (like
 jump in streamfunction) to grid data `Θ` (like dilatation, i.e. divergence of velocity).
 This is the adjoint of [`surface_grad_cross!`](@ref).
 Note that the differential operations are divided either by 1 or by the grid cell size,
@@ -406,7 +406,7 @@ end
     surface_grad_cross!(γ::ScalarData,ϕ::Nodes{Primal},cache::BasicILMCache)
     surface_grad_cross!(γ::ScalarData,ϕ::Nodes{Primal},sys::ILMSystem)
 
-The operation ``\\gamma = \\hat{G}_s\\phi = e_z \\cdot (n \\times R_f^T G\\phi)``, which maps grid data `ϕ` (like
+The operation ``\\gamma = \\hat{G}_s\\phi = \\mathbf{e}_z \\cdot (\\mathbf{n} \\times R_f^T G\\phi)``, which maps grid data `ϕ` (like
 scalar potential) to scalar surface data `γ` (like surface vorticity). This is the adjoint of [`surface_divergence_cross!`](@ref).
 Note that
 the differential operations are divided either by 1 or by the grid cell size,

--- a/src/system.jl
+++ b/src/system.jl
@@ -44,7 +44,8 @@ for f in [:zeros_surface,:zeros_grid,:zeros_gridcurl,:zeros_gridgrad,
           :ones_surface,:ones_grid,:ones_gridgrad,:ones_gridcurl,
           :x_grid,:y_grid,:x_gridcurl,:y_gridcurl,
           :normals,:areas,:points,
-          :create_nRTRn,:create_GLinvD,:create_CLinvCT,:create_RTLinvR,
+          :create_nRTRn,:create_GLinvD,:create_CLinvCT,:create_CL2invCT,
+          :create_RTLinvR,
           :create_GLinvD_cross,:create_surface_filter]
    @eval $f(sys::ILMSystem) = $f(sys.base_cache)
 end

--- a/test/literate/matrices.jl
+++ b/test/literate/matrices.jl
@@ -61,7 +61,9 @@ obtain this matrix with [`create_surface_filter`](@ref).
 #md # ```@docs
 #md # create_RTLinvR
 #md # create_CLinvCT
+#md # create_CL2invCT
 #md # create_GLinvD
+#md # create_GLinvD_cross
 #md # create_nRTRn
 #md # create_surface_filter
 #md # ```

--- a/test/literate/neumann.jl
+++ b/test/literate/neumann.jl
@@ -118,7 +118,7 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
     vn .= 0.5*(vnplus+vnminus)
     dvn .= vnplus - vnminus
 
-    # Find the potential
+    ## Find the potential
     regularize!(fstar,dvn,base_cache)
     inverse_laplacian!(fstar,base_cache)
 
@@ -130,7 +130,7 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
     inverse_laplacian!(f,base_cache)
     f .+= fstar
 
-    # Find the streamfunction
+    ## Find the streamfunction
     surface_curl!(sstar,df,base_cache)
 
     surface_grad_cross!(ds,fstar,base_cache)

--- a/test/literate/neumann.jl
+++ b/test/literate/neumann.jl
@@ -98,6 +98,7 @@ function ImmersedLayers.prob_cache(prob::NeumannPoissonProblem,base_cache::Basic
     NeumannPoissonCache(S,dvn,vn,fstar,sstar)
 end
 nothing #hide
+
 #=
 And finally, here's the steps we outlined above, used to
 extend the `solve` function
@@ -117,6 +118,7 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
     vn .= 0.5*(vnplus+vnminus)
     dvn .= vnplus - vnminus
 
+    # Find the potential
     regularize!(fstar,dvn,base_cache)
     inverse_laplacian!(fstar,base_cache)
 
@@ -128,6 +130,7 @@ function ImmersedLayers.solve(vnplus,vnminus,prob::NeumannPoissonProblem,sys::IL
     inverse_laplacian!(f,base_cache)
     f .+= fstar
 
+    # Find the streamfunction
     surface_curl!(sstar,df,base_cache)
 
     surface_grad_cross!(ds,fstar,base_cache)
@@ -150,6 +153,9 @@ with $v_n^+ = n_x$ and $v_n^- = 0$. This is actually the set of conditions
 used to compute the unit scalar potential field (and, as we will see, the added mass) in potential flow.
 =#
 
+#=
+Set up the grid
+=#
 Δx = 0.01
 Lx = 4.0
 xlim = (-Lx/2,Lx/2)
@@ -189,7 +195,18 @@ plot(s,sys,layers=true,levels=30,title="ψ"))
 #=
 and the Lagrange multiplier field, $[\phi]$, on the surface
 =#
-plot(ds)
+plot(df)
+
+#=
+If, instead, we set the inner boundary condition to $n_x$ and the
+outer to zero, then we get the flow *inside* of a translating circle
+=#
+vnplus = zeros_surface(sys)
+vnminus = zeros_surface(sys)
+vnminus .= nrm.u
+f, df, s, ds = solve(vnplus,vnminus,prob,sys);
+plot(plot(f,sys,layers=true,levels=30,title="ϕ"),
+plot(s,sys,layers=true,levels=30,title="ψ"))
 
 #=
 ## Multiple bodies

--- a/test/literate/stokes.jl
+++ b/test/literate/stokes.jl
@@ -1,0 +1,192 @@
+# # Stokes flow
+
+#md # ```@meta
+#md # CurrentModule = ImmersedLayers
+#md # ```
+
+#=
+Here, we'll demonstrate a solution of the Stokes equations,
+with Dirichlet (i.e. no-slip) boundary conditions on a surface.
+The purpose of this case is to demonstrate the use of the tools with
+vector-valued data -- in this case, the fluid velocity field.
+
+The governing equations for this problem can be written as
+
+$$\mu \nabla^2 \omega - \nabla \times (\delta(\chi) \sigma) = \nabla\times \nabla \cdot (\delta(\chi)\mathbf{\Sigma})$$
+$$\delta^T(\chi) \mathbf{v} = \overline{\mathbf{v}}_b$$
+$$\mathbf{v} = \nabla \phi + \nabla\times \psi$$
+
+where $\psi$ and $\phi$ are the solutions of
+
+$$\nabla^2 \psi = -\omega$$
+$$\nabla^2 \phi = \delta(\chi) \mathbf{n}\cdot [\mathbf{v}_b]$$
+
+and $\mathbf{\Sigma} = \mu ([\mathbf{v}_b]\mathbf{n} + \mathbf{n} [\mathbf{v}_b])$ is a surface viscous flux tensor;
+and $[\mathbf{v}_b] = \mathbf{v}_b^+ - \mathbf{v}_b^-$ and $\overline{v}_b = (\mathbf{v}_b^+ + \mathbf{v}_b^-)/2$ are
+the jump and average of the surface velocities on either side of a surface.
+
+We can discretize and combine these equations into a saddle-point form for $\psi$ and $\sigma$:
+
+$$\begin{bmatrix}L^2 & C_s^T \\ C_s & 0 \end{bmatrix}\begin{pmatrix} \psi \\ \sigma \end{pmatrix} = \begin{pmatrix} -C D_s [\mathbf{v}_b]  \\ \overline{v}_b - G_s L^{-1} R \mathbf{n}\cdot [\mathbf{v}_b]  \end{pmatrix}$$
+
+This saddle-point system has a form similar to the one we got 
+=#
+
+using ImmersedLayers
+using Plots
+using LinearAlgebra
+using UnPack
+
+#=
+## Set up the extra cache and solve function
+=#
+#=
+The problem type takes the usual basic form
+=#
+struct StokesFlowProblem{DT,ST} <: ImmersedLayers.AbstractVectorILMProblem{DT,ST}
+   g :: PhysicalGrid
+   bodies :: BodyList
+   StokesFlowProblem(g::PT,bodies::BodyList;ddftype=CartesianGrids.Yang3,scaling=IndexScaling) where {PT} = new{ddftype,scaling}(g,bodies)
+   StokesFlowProblem(g::PT,body::Body;ddftype=CartesianGrids.Yang3,scaling=IndexScaling) where {PT} = new{ddftype,scaling}(g,BodyList([body]))
+end
+
+#=
+As with other cases, the extra cache holds additional intermediate data, as well as
+the Schur complement. We don't bother creating a filtering matrix here.
+=#
+struct StokesFlowCache{SMT,RCT,DVT,VNT,ST,VFT,FT} <: AbstractExtraILMCache
+   S :: SMT
+   Rc :: RCT
+   dv :: DVT
+   vb :: DVT
+   vprime :: DVT
+   dvn :: VNT
+   sstar :: ST
+   vϕ :: VFT
+   ϕ :: FT
+end
+
+function ImmersedLayers.prob_cache(prob::StokesFlowProblem,base_cache::BasicILMCache)
+    S = create_CL2invCT(base_cache)
+
+    dv = zeros_surface(base_cache)
+    vb = zeros_surface(base_cache)
+    vprime = zeros_surface(base_cache)
+
+    dvn = ScalarData(dv)
+    sstar = zeros_gridcurl(base_cache)
+    vϕ = zeros_grid(base_cache)
+    ϕ = Nodes(Primal,sstar)
+
+    Rc = RegularizationMatrix(base_cache,dvn,ϕ)
+
+    StokesFlowCache(S,Rc,dv,vb,vprime,dvn,sstar,vϕ,ϕ)
+end
+
+Δx = 0.01
+Lx = 4.0
+xlim = (-Lx/2,Lx/2)
+ylim = (-Lx/2,Lx/2)
+g = PhysicalGrid(xlim,ylim,Δx)
+Δs = 1.4*cellsize(g);
+
+function ImmersedLayers.solve(vsplus,vsminus,prob::StokesFlowProblem,sys::ILMSystem)
+    @unpack extra_cache, base_cache = sys
+    @unpack S, Rc, dv, vb, vprime, sstar, dvn, vϕ, ϕ  = extra_cache
+
+    σ = zeros_surface(sys)
+    s = zeros_gridcurl(sys)
+    v = zeros_grid(sys)
+
+    dv .= vsplus-vsminus
+    vb .= 0.5*(vsplus + vsminus)
+
+    ## Compute ψ*
+    surface_divergence!(v,dv,sys)
+    curl!(sstar,v,sys)
+    sstar .*= -1.0
+
+    inverse_laplacian!(sstar,sys)
+    inverse_laplacian!(sstar,sys)
+
+    ## Adjustment for jump in normal velocity
+    pointwise_dot!(dvn,nrm,dv)
+    regularize!(ϕ,dvn,Rc)
+    inverse_laplacian!(ϕ,sys)
+    grad!(vϕ,ϕ,sys)
+    interpolate!(vprime,vϕ,sys)
+    vprime .= vb - vprime
+
+    ## Compute surface velocity due to ψ*
+    curl!(v,sstar,sys)
+    interpolate!(vb,v,sys)
+
+    ## Spurious slip
+    vprime .-= vb
+    σ .= S\vprime
+
+    ## Correction streamfunction
+    surface_curl!(s,σ,sys)
+    s .*= -1.0
+    inverse_laplacian!(s,sys)
+    inverse_laplacian!(s,sys)
+
+    ## Correct
+    s .+= sstar
+
+    ## Assemble the velocity
+    curl!(v,s,sys)
+    v .+= vϕ
+
+    return v, s, σ, vprime
+end
+
+body = Circle(0.5,Δs)
+
+prob = StokesFlowProblem(g,body,scaling=GridScaling)
+
+sys = ImmersedLayers.__init(prob);
+
+pts = points(sys);
+nrm = normals(sys);
+
+vsplus = zeros_surface(sys);
+vsminus = zeros_surface(sys);
+vsplus.u .= -nrm.v;
+vsplus.v .= nrm.u;
+##vsplus.u .= 1.0;
+##vsplus.v .= 0.0;
+
+vsminus.u .= 0.0;
+
+@time v, s, σ, vprime = solve(vsplus,vsminus,prob,sys);
+
+plot(v,sys)
+
+plot(s,sys)
+
+vb = zeros_surface(sys);
+vb .= 0.5*(vsplus + vsminus);
+vs = zeros_surface(sys);
+
+interpolate!(vs,v,sys);
+
+plot(vs)
+
+plot(σ.u)
+
+F = svd(sys.extra_cache.S);
+
+plot(1.0./F.S,yscale=:log10)
+plot!(F.S./(F.S.^2 .+ 1e-6))
+
+σ2 = zeros_surface(sys);
+
+Σ⁺ = Diagonal(F.S./(F.S.^2 .+ 1e-6))
+S⁺ = F.Vt'*Σ⁺*F.U';
+σ2 .= S⁺*vprime;
+
+plot(σ.u)
+plot!(σ2.u)
+
+norm(sys.extra_cache.S*σ2-vprime)


### PR DESCRIPTION
This PR extends the definition of the surface curl `surface_curl!` to

C^T_s v = ∇× (R v)

where v is vector-valued surface data, mapping it to dual grid nodes (vorticity). The transpose of this is

C_s Ψ = R^T ∇×Ψ 

where Ψ is grid data (dual nodes), like streamfunction, mapping it to surface vector data, like velocity.

This supports, e.g., Navier-Stokes and Stokes applications.

