### PR TITLE
Arbitrary data type in cache and systems

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -154,17 +154,18 @@ for details.
 
 function SurfaceScalarCache(bl::BodyList,a::ScalarData{N},nrm::VectorData{N},g::PhysicalGrid;
                               ddftype = CartesianGrids.Yang3,
-                              scaling = IndexScaling) where {N}
+                              scaling = IndexScaling,
+                              dtype = Float64) where {N}
 
-   X = points(bl)
-   sdata_cache = ScalarData(X)
-   snorm_cache = VectorData(X)
+	X = points(bl)
+	sdata_cache = ScalarData(X, dtype = dtype)
+	snorm_cache = VectorData(X, dtype = dtype)
 
-   gsnorm_cache = Edges(Primal,size(g))
-   gcurl_cache = Nodes(Dual,size(g))
-   gdata_cache = Nodes(Primal,size(g))
+	gsnorm_cache = Edges(Primal,size(g), dtype = dtype)
+	gcurl_cache = Nodes(Dual,size(g), dtype = dtype)
+	gdata_cache = Nodes(Primal,size(g), dtype = dtype)
 
-   _surfacecache(bl,X,a,nrm,g,ddftype,scaling,sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache)
+	_surfacecache(bl,X,a,nrm,g,ddftype,scaling,sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache;dtype=dtype)
 
 end
 
@@ -172,17 +173,18 @@ end
 
 function SurfaceVectorCache(bl::BodyList,a::ScalarData{N},nrm::VectorData{N},g::PhysicalGrid;
                               ddftype = CartesianGrids.Yang3,
-                              scaling = IndexScaling) where {N}
+                              scaling = IndexScaling,
+                              dtype = Float64) where {N}
 
-   X = points(bl)
-   sdata_cache = VectorData(X)
-   snorm_cache = TensorData(X)
+	X = points(bl)
+	sdata_cache = VectorData(X, dtype = dtype)
+	snorm_cache = TensorData(X, dtype = dtype)
 
-   gsnorm_cache = EdgeGradient(Primal,size(g))
-   gcurl_cache = Nodes(Dual,size(g))
-   gdata_cache = Edges(Primal,size(g))
+	gsnorm_cache = EdgeGradient(Primal,size(g), dtype = dtype)
+	gcurl_cache = Nodes(Dual,size(g), dtype = dtype)
+	gdata_cache = Edges(Primal,size(g), dtype = dtype)
 
-   _surfacecache(bl,X,a,nrm,g,ddftype,scaling,sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache)
+	_surfacecache(bl,X,a,nrm,g,ddftype,scaling,sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache;dtype=dtype)
 
 end
 
@@ -193,7 +195,7 @@ function Base.show(io::IO, H::BasicILMCache{N,SCA}) where {N,SCA}
 end
 
 function _surfacecache(bl::BodyList,X::VectorData{N},a,nrm,g::PhysicalGrid{ND},ddftype,scaling,
-                      sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache) where {N,ND}
+                      sdata_cache,snorm_cache,gsnorm_cache,gcurl_cache,gdata_cache;dtype=Float64) where {N,ND}
 
   regop = _get_regularization(X,a,g,ddftype,scaling)
   Rsn = _regularization_matrix(regop,snorm_cache,gsnorm_cache)
@@ -204,7 +206,7 @@ function _surfacecache(bl::BodyList,X::VectorData{N},a,nrm,g::PhysicalGrid{ND},d
 
   coeff_factor = 1.0
   with_inverse = true
-  L = _get_laplacian(gcurl_cache,coeff_factor,g,with_inverse,scaling)
+  L = _get_laplacian(gcurl_cache,coeff_factor,g,scaling;dtype=dtype)
 
   return BasicILMCache{N,scaling,typeof(gdata_cache),ND,typeof(bl),typeof(nrm),typeof(a),typeof(regop),typeof(Rsn),typeof(Esn),typeof(R),typeof(E),typeof(L),
                        typeof(gsnorm_cache),typeof(gcurl_cache),typeof(snorm_cache),typeof(sdata_cache)}(
@@ -257,9 +259,10 @@ _get_regularization(X::VectorData{N},a::ScalarData{N},g::PhysicalGrid,ddftype,::
 _get_regularization(body::Union{Body,BodyList},args...;kwargs...) = _get_regularization(VectorData(collect(body)),areas(body),args...;kwargs...)
 
 # Standardize the Laplacian
-_get_laplacian(a,coeff_factor::Real,g::PhysicalGrid,with_inverse,::Type{IndexScaling}) = plan_laplacian(size(a),with_inverse=with_inverse,factor=coeff_factor)
-_get_laplacian(a,coeff_factor::Real,g::PhysicalGrid,with_inverse,::Type{GridScaling}) =  plan_laplacian(size(a),with_inverse=with_inverse,factor=coeff_factor/cellsize(g)^2)
-
+_get_laplacian(a,coeff_factor::Real,g::PhysicalGrid,::Type{IndexScaling};dtype=Float64) =
+               CartesianGrids.plan_laplacian(size(a),with_inverse=true,factor=coeff_factor,dtype=dtype)
+_get_laplacian(a,coeff_factor::Real,g::PhysicalGrid,::Type{GridScaling};dtype=Float64) =
+               CartesianGrids.plan_laplacian(size(a),with_inverse=true,factor=coeff_factor/cellsize(g)^2,dtype=dtype)
 
 # This is needed to stabilize the type-unstable `RegularizationMatrix` function in
 # CartesianGrids
@@ -305,8 +308,8 @@ Create an invertible Laplacian operator for data `src` (of the same size as the 
 using the index or grid scaling associated with `cache`. The operator is pre-multiplied
 by the factor `coeff_factor`.
 """
-Laplacian(cache::BasicILMCache{N,SCA},src::GridData,coeff_factor; with_inverse=true) where {N,SCA} =
-    _get_laplacian(src,coeff_factor,cache.g,with_inverse,SCA)
+Laplacian(cache::BasicILMCache{N,SCA},src::GridData,coeff_factor; with_inverse=true, dtype=Float64) where {N,SCA} =
+    _get_laplacian(src,coeff_factor,cache.g,with_inverse,SCA;dtype=dtype)
 
 
 # Some utilities to get the DDF type of the cache

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -205,7 +205,6 @@ function _surfacecache(bl::BodyList,X::VectorData{N},a,nrm,g::PhysicalGrid{ND},d
   E = _interpolation_matrix(regop, gdata_cache,sdata_cache)
 
   coeff_factor = 1.0
-  with_inverse = true
   L = _get_laplacian(gcurl_cache,coeff_factor,g,scaling;dtype=dtype)
 
   return BasicILMCache{N,scaling,typeof(gdata_cache),ND,typeof(bl),typeof(nrm),typeof(a),typeof(regop),typeof(Rsn),typeof(Esn),typeof(R),typeof(E),typeof(L),

--- a/src/grid_operators.jl
+++ b/src/grid_operators.jl
@@ -27,7 +27,14 @@ function divergence!(p::Nodes{Primal,NX,NY},q::Edges{Primal,NX,NY},cache::BasicI
     _scale_derivative!(p,cache)
 end
 
+function divergence!(p::Nodes{Dual,NX,NY},q::Edges{Dual,NX,NY},cache::BasicILMCache) where {NX,NY}
+    _unscaled_divergence!(p,q,cache)
+    _scale_derivative!(p,cache)
+end
+
 _unscaled_divergence!(p,q,cache::BasicILMCache) = (fill!(p,0.0); divergence!(p,q))
+
+
 
 """
     grad!(v::Edges{Primal},p::Nodes{Primal},cache::BasicILMCache)

--- a/src/matrix_operators.jl
+++ b/src/matrix_operators.jl
@@ -227,7 +227,11 @@ function create_surface_filter(cache::BasicILMCache{N,SCA}) where {N,SCA}
     Ef = InterpolationMatrix(regfilt,gdata_cache,sdata_cache)
 
     len = length(sdata_cache)
-    C = Matrix{eltype(sdata_cache)}(undef,len,len)
+
+    # Keep C as a Matrix{Float64} for now
+    # C = Matrix{eltype(sdata_cache)}(undef,len,len)
+    C = Matrix{Float64}(undef,len,len)
+
     return mul!(C,Ef,R)
 
 end


### PR DESCRIPTION
1. Allow arbitrary data type in cache and systems.
2. Add a wrapper for divergence of dual edges data.