### PR TITLE
Formalized bc operations

### DIFF
--- a/docs/src/manual/heatconduction.md
+++ b/docs/src/manual/heatconduction.md
@@ -85,15 +85,12 @@ in the first argument. This represents this function's contribution to $dT/dt$.
 ````@example heatconduction
 function heatconduction_ode_rhs!(dT,T,sys::ILMSystem,t)
     @unpack bc, forcing, phys_params, extra_cache, base_cache = sys
-    @unpack dTb, Tbplus, Tbminus = extra_cache
+    @unpack dTb = extra_cache
 
     κ = phys_params["diffusivity"]
 
     # Calculate the double-layer term
-    fill!(dT,0.0)
-    Tbplus .= bc["Tbplus"](t,base_cache,phys_params)
-    Tbminus .= bc["Tbminus"](t,base_cache,phys_params)
-    dTb .= Tbplus - Tbminus
+    prescribed_surface_jump!(dTb,t,sys)
     surface_divergence!(dT,-κ*dTb,sys)
 
     return dT
@@ -106,13 +103,7 @@ and exterior prescribed values. The first argument `dTb` holds the result.
 
 ````@example heatconduction
 function heatconduction_bc_rhs!(dTb,sys::ILMSystem,t)
-    @unpack bc, extra_cache, base_cache, phys_params = sys
-    @unpack Tb, Tbplus, Tbminus = extra_cache
-
-    Tbplus .= bc["Tbplus"](t,base_cache,phys_params)
-    Tbminus .= bc["Tbminus"](t,base_cache,phys_params)
-    dTb .= 0.5*(Tbplus + Tbminus)
-
+    prescribed_surface_average!(dTb,t,sys)
     return dTb
 end
 ````
@@ -123,11 +114,7 @@ to the grid.
 
 ````@example heatconduction
 function heatconduction_constraint_force!(dT,σ,sys::ILMSystem)
-    @unpack extra_cache, base_cache = sys
-
-    fill!(dT,0.0)
     regularize!(dT,-σ,sys)
-
     return dT
 end
 ````
@@ -138,11 +125,7 @@ holds the result.
 
 ````@example heatconduction
 function heatconduction_bc_op!(dTb,T,sys::ILMSystem)
-    @unpack extra_cache, base_cache = sys
-
-    fill!(dTb,0.0)
     interpolate!(dTb,T,sys)
-
     return dTb
 end
 ````
@@ -162,11 +145,8 @@ force* vectors. Here, the state is the grid temperature data and the constraint
 is the Lagrange multipliers on the boundary.
 
 ````@example heatconduction
-struct DirichletHeatConductionCache{DTT,TBT,TBP,TBM,FT} <: AbstractExtraILMCache
+struct DirichletHeatConductionCache{DTT,FT} <: AbstractExtraILMCache
    dTb :: DTT
-   Tb :: TBT
-   Tbplus :: TBP
-   Tbminus :: TBM
    f :: FT
 end
 
@@ -176,9 +156,6 @@ function ImmersedLayers.prob_cache(prob::DirichletHeatConductionProblem,
     @unpack gdata_cache, g = base_cache
 
     dTb = zeros_surface(base_cache)
-    Tb = zeros_surface(base_cache)
-    Tbplus = zeros_surface(base_cache)
-    Tbminus = zeros_surface(base_cache)
 
     # Construct a Lapacian outfitted with the diffusivity
     κ = phys_params["diffusivity"]
@@ -193,7 +170,7 @@ function ImmersedLayers.prob_cache(prob::DirichletHeatConductionProblem,
                         constraint_force = heatconduction_constraint_force!,
                         bc_op = heatconduction_bc_op!)
 
-    DirichletHeatConductionCache(dTb,Tb,Tbplus,Tbminus,f)
+    DirichletHeatConductionCache(dTb,f)
 end
 ````
 
@@ -247,12 +224,15 @@ phys_params = Dict("diffusivity" => 1.0, "Fourier" => 1.0)
 ````
 
 The temperature boundary functions on the exterior and interior are
-defined here and assembled into a dict.
+defined here and assembled into a dict. Note that these functions
+must have a slightly more complex signature than in time-invariant
+problems: for generality, they must accept the time argument and
+another argument accepting possible motions of the surfaces.
 
 ````@example heatconduction
-get_Tbplus(t,base_cache,phys_params) = zeros_surface(base_cache)
-get_Tbminus(t,base_cache,phys_params) = ones_surface(base_cache)
-bcdict = Dict("Tbplus" => get_Tbplus,"Tbminus" => get_Tbminus)
+get_Tbplus(t,base_cache,phys_params,motions) = zeros_surface(base_cache)
+get_Tbminus(t,base_cache,phys_params,motions) = ones_surface(base_cache)
+bcdict = Dict("exterior" => get_Tbplus,"interior" => get_Tbminus)
 ````
 
 Construct the problem, passing in the data and functions we've just

--- a/docs/src/manual/helmholtz.md
+++ b/docs/src/manual/helmholtz.md
@@ -67,8 +67,10 @@ scalarpotential_from_masked_divv!
 vectorpotential_from_curlv!
 vecfield_from_vectorpotential!
 masked_curlv_from_curlv_masked!
+curlv_masked_from_masked_curlv!
 scalarpotential_from_divv!
 masked_divv_from_divv_masked!
+divv_masked_from_masked_divv!
 vecfield_from_scalarpotential!
 vecfield_helmholtz!
 vectorpotential_uniformvecfield!

--- a/docs/src/manual/neumann.md
+++ b/docs/src/manual/neumann.md
@@ -116,11 +116,9 @@ function ImmersedLayers.solve(prob::NeumannPoissonProblem,sys::ILMSystem)
     df = zeros_surface(base_cache)
     ds = zeros_surface(base_cache)
 
-    vnplus = bc["vnplus function"](base_cache,phys_params)
-    vnminus = bc["vnminus function"](base_cache,phys_params)
-
-    vn .= 0.5*(vnplus+vnminus)
-    dvn .= vnplus - vnminus
+    # Get the precribed jump and average of the surface normal derivatives
+    prescribed_surface_jump!(dvn,sys)
+    prescribed_surface_average!(vn,sys)
 
     # Find the potential
     regularize!(fstar,dvn,base_cache)
@@ -180,7 +178,7 @@ function get_vnplus(base_cache,phys_params)
 end
 get_vnminus(base_cache,phys_params) = zeros_surface(base_cache)
 
-bcdict = Dict("vnplus function"=>get_vnplus,"vnminus function"=>get_vnminus)
+bcdict = Dict("exterior"=>get_vnplus,"interior"=>get_vnminus)
 ````
 
 Create the system
@@ -275,7 +273,7 @@ function get_vnminus(base_cache,phys_params)
     vnminus = zeros_surface(base_cache)
     return vnminus
 end
-bcdict = Dict("vnplus function"=>get_vnplus,"vnminus function"=>get_vnminus)
+bcdict = Dict("exterior"=>get_vnplus,"interior"=>get_vnminus)
 ````
 
 Create the problem and system

--- a/docs/src/manual/problems.md
+++ b/docs/src/manual/problems.md
@@ -167,10 +167,10 @@ of freedom in this approach, as we will demonstrate.
 Here, we wish to construct functions that return the value of `f`
 on the outside and inside of the surface. These functions will
 get called in the `solve` function, and they will be passed
-the base cache and the physical parameters. So we can make use
+the base cache, the physical parameters. So we can make use
 of both of these to return the boundary data, e.g., here
 we return the `x` coordinate of the surface points on the outside
-of the surface, and zeros on the inside:
+of the surface, and zeros on the inside.
 
 ````@example problems
 get_fbplus(base_cache,phys_params) = points(base_cache).u
@@ -178,11 +178,12 @@ get_fbminus(base_cache,phys_params) = zeros_surface(base_cache)
 ````
 
 Using the `bc` keyword, we can pass these along to the problem specification
-by various means. It's at the user's discretion how to do it, and how to make use of them
-in the solution. Here's an example, using a `Dict`:
+by various means. To make use of some routines that automate the
+application of these functions, we must pass them in a `Dict`, with the
+keys `exterior` and `interior`, respectively.
 
 ````@example problems
-bcdict = Dict("fbplus function"=>get_fbplus,"fbminus function"=>get_fbminus)
+bcdict = Dict("exterior"=>get_fbplus,"interior"=>get_fbminus)
 ````
 
 ### Forcing
@@ -271,24 +272,27 @@ function ImmersedLayers.solve(prob::DirichletPoissonProblem,sys::ILMSystem)
     f = zeros_grid(base_cache)
     s = zeros_surface(base_cache)
 
-    # Get the boundary data on each side of the interface using
-    # the functions we supplied via the `Dict`.
-    fbplus = bc["fbplus function"](base_cache,phys_params)
-    fbminus = bc["fbminus function"](base_cache,phys_params)
-
     # apply_forcing! evaluates the forcing field on the grid and put
     # the result in the `gdata_cache`.
     fill!(gdata_cache,0.0)
     apply_forcing!(gdata_cache,f,0.0,forcing_cache,phys_params)
 
+    # Get the prescribed jump in boundary data across the interface using
+    # the functions we supplied via the `Dict`.
+    prescribed_surface_jump!(fb,sys)
+
     # Evaluate the double-layer term and add it to the right-hand side
-    surface_divergence!(fstar,fbplus-fbminus,base_cache)
+    surface_divergence!(fstar,fb,base_cache)
     fstar .+= gdata_cache
 
-    fb .= 0.5*(fbplus+fbminus)
-
+    # Intermediate solution
     inverse_laplacian!(fstar,base_cache)
 
+    # Get the prescribed average of boundary data on the interface using
+    # the functions we supplied via the `Dict`.
+    prescribed_surface_average!(fb,sys)
+
+    # Correction
     interpolate!(s,fstar,base_cache)
     s .= fb - s
     s .= -(S\s);
@@ -320,8 +324,8 @@ example, to create an internal solution, with surface data equal to the $y$ coor
 and four sources inside.
 
 ````@example problems
-get_fbplus(base_cache,phys_params) = zeros_surface(base_cache)
-get_fbminus(base_cache,phys_params) = points(base_cache).v
+get_fbplus(base_cache,phys_params,motions) = zeros_surface(base_cache)
+get_fbminus(base_cache,phys_params,motions) = points(base_cache).v
 
 function my_point_positions(state,t,fr::PointRegionCache,phys_params)
     x = [-0.2,0.2,-0.2,0.2]

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -91,6 +91,9 @@ include("matrix_operators.jl")
 include("helmholtz.jl")
 include("timemarching.jl")
 include("output.jl")
+include("bc.jl")
+
+include("viscous-flow.jl")
 
 include("plot_recipes.jl")
 

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -56,7 +56,8 @@ export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
         create_GLinvD_cross,create_surface_filter,
         AreaRegionCache,LineRegionCache,PointRegionCache,arccoord,
         ForcingModelAndRegion,apply_forcing!,
-        solve, @snapshotoutput
+        solve, @snapshotoutput,
+        prescribed_surface_jump!,prescribed_surface_average!
 
 abstract type LayerType{N} end
 

--- a/src/bc.jl
+++ b/src/bc.jl
@@ -1,0 +1,56 @@
+# Boundary condition functions
+
+for f in [:prescribed_surface_jump!,:prescribed_surface_average!]
+  @eval function $f(dfb,t::Real,sys::ILMSystem)
+          @unpack base_cache, bc, phys_params = sys
+          $f(dfb,t,base_cache,bc,phys_params)
+        end
+  @eval function $f(dfb,sys::ILMSystem)
+          @unpack base_cache, bc, phys_params = sys
+          $f(dfb,base_cache,bc,phys_params)
+        end
+end
+
+function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{N},bc,phys_params) where N
+    dfb .= bc["exterior"](t,base_cache,phys_params)
+    dfb .-= bc["interior"](t,base_cache,phys_params)
+    return dfb
+end
+
+function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{N},bc,phys_params) where N
+    dfb .= bc["exterior"](base_cache,phys_params)
+    dfb .-= bc["interior"](base_cache,phys_params)
+    return dfb
+end
+
+function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(dfb,0.0)
+    return dfb
+end
+
+function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(dfb,0.0)
+    return dfb
+end
+
+function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{N},bc,phys_params) where N
+    fb .= 0.5*bc["exterior"](t,base_cache,phys_params)
+    fb .+= 0.5*bc["interior"](t,base_cache,phys_params)
+    return fb
+end
+
+function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(fb,0.0)
+    return fb
+end
+
+function prescribed_surface_average!(fb,base_cache::BasicILMCache{N},bc,phys_params) where N
+    fb .= 0.5*bc["exterior"](base_cache,phys_params)
+    fb .+= 0.5*bc["interior"](base_cache,phys_params)
+    return fb
+end
+
+function prescribed_surface_average!(fb,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(fb,0.0)
+    return fb
+end

--- a/src/bc.jl
+++ b/src/bc.jl
@@ -2,8 +2,8 @@
 
 for f in [:prescribed_surface_jump!,:prescribed_surface_average!]
   @eval function $f(dfb,t::Real,sys::ILMSystem)
-          @unpack base_cache, bc, phys_params = sys
-          $f(dfb,t,base_cache,bc,phys_params)
+          @unpack base_cache, bc, phys_params, motions = sys
+          $f(dfb,t,base_cache,bc,phys_params,motions)
         end
   @eval function $f(dfb,sys::ILMSystem)
           @unpack base_cache, bc, phys_params = sys
@@ -11,9 +11,9 @@ for f in [:prescribed_surface_jump!,:prescribed_surface_average!]
         end
 end
 
-function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{N},bc,phys_params) where N
-    dfb .= bc["exterior"](t,base_cache,phys_params)
-    dfb .-= bc["interior"](t,base_cache,phys_params)
+function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{N},bc,phys_params,motions) where N
+    dfb .= bc["exterior"](t,base_cache,phys_params,motions)
+    dfb .-= bc["interior"](t,base_cache,phys_params,motions)
     return dfb
 end
 
@@ -23,7 +23,7 @@ function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{N},bc,phys_param
     return dfb
 end
 
-function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{0},bc,phys_params)
+function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{0},bc,phys_params,motions)
     fill!(dfb,0.0)
     return dfb
 end
@@ -33,13 +33,13 @@ function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{0},bc,phys_param
     return dfb
 end
 
-function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{N},bc,phys_params) where N
-    fb .= 0.5*bc["exterior"](t,base_cache,phys_params)
-    fb .+= 0.5*bc["interior"](t,base_cache,phys_params)
+function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{N},bc,phys_params,motions) where N
+    fb .= 0.5*bc["exterior"](t,base_cache,phys_params,motions)
+    fb .+= 0.5*bc["interior"](t,base_cache,phys_params,motions)
     return fb
 end
 
-function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{0},bc,phys_params)
+function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{0},bc,phys_params,motions)
     fill!(fb,0.0)
     return fb
 end

--- a/src/viscous-flow.jl
+++ b/src/viscous-flow.jl
@@ -1,0 +1,443 @@
+#= Setting up the cache =#
+
+@ilmproblem ViscousIncompressibleFlow vector
+
+struct ViscousIncompressibleFlowCache{CDT,FRT,DVT,VFT,VORT,DILT,VELT,FCT} <: AbstractExtraILMCache
+   cdcache :: CDT
+   fcache :: FRT
+   dvb :: DVT
+   vb_tmp :: DVT
+   v_tmp :: VFT
+   dv :: VFT
+   dv_tmp :: VFT
+   w_tmp :: VORT
+   divv_tmp :: DILT
+   velcache :: VELT
+   f :: FCT
+end
+
+function ImmersedLayers.prob_cache(prob::ViscousIncompressibleFlowProblem,
+                                   base_cache::BasicILMCache{N,scaling}) where {N,scaling}
+    @unpack phys_params, forcing = prob
+    @unpack gdata_cache, gcurl_cache, g = base_cache
+
+    dvb = zeros_surface(base_cache)
+    vb_tmp = zeros_surface(base_cache)
+
+    v_tmp = zeros_grid(base_cache)
+    dv = zeros_grid(base_cache)
+    dv_tmp = zeros_grid(base_cache)
+    w_tmp = zeros_gridcurl(base_cache)
+    divv_tmp = zeros_griddiv(base_cache)
+
+    velcache = VectorFieldCache(base_cache)
+
+    # Construct a Lapacian outfitted with the viscosity
+    Re = phys_params["Re"]
+    viscous_L = Laplacian(base_cache,gcurl_cache,1.0/Re)
+
+    # Create cache for the convective derivative
+    cdcache = ConvectiveDerivativeCache(base_cache)
+
+    # Create cache for the forcing regions
+    fcache = ForcingModelAndRegion(forcing["forcing models"],base_cache);
+
+
+    # The state here is vorticity, the constraint is the surface traction
+    f = _get_ode_function_list(viscous_L,base_cache)
+
+    ViscousIncompressibleFlowCache(cdcache,fcache,dvb,vb_tmp,v_tmp,dv,dv_tmp,w_tmp,divv_tmp,velcache,f)
+end
+
+_get_ode_function_list(viscous_L,base_cache::BasicILMCache{N}) where {N} =
+                ODEFunctionList(state = zeros_gridcurl(base_cache),
+                                constraint = zeros_surface(base_cache),
+                                ode_rhs=viscousflow_vorticity_ode_rhs!,
+                                lin_op=viscous_L,
+                                bc_rhs=viscousflow_vorticity_bc_rhs!,
+                                constraint_force = viscousflow_vorticity_constraint_force!,
+                                bc_op = viscousflow_vorticity_bc_op!)
+
+_get_ode_function_list(viscous_L,base_cache::BasicILMCache{0}) =
+                 ODEFunctionList(state = zeros_gridcurl(base_cache),
+                                 ode_rhs=viscousflow_vorticity_ode_rhs!,
+                                 lin_op=viscous_L)
+
+#= ODE functions =#
+
+function viscousflow_vorticity_ode_rhs!(dw,w,sys::ILMSystem,t)
+  @unpack extra_cache, base_cache = sys
+  @unpack v_tmp, dv = extra_cache
+
+  velocity!(v_tmp,w,sys,t)
+  viscousflow_velocity_ode_rhs!(dv,v_tmp,sys,t)
+  curl!(dw,dv,base_cache)
+
+  return dw
+end
+
+function viscousflow_velocity_ode_rhs!(dv,v,sys::ILMSystem,t)
+    @unpack bc, forcing, phys_params, extra_cache, base_cache = sys
+    @unpack dvb, dv_tmp, cdcache, fcache = extra_cache
+
+    Re = phys_params["Re"]
+    over_Re = 1.0/Re
+
+    fill!(dv,0.0)
+
+    # Calculate the convective derivative
+    convective_derivative!(dv_tmp,v,base_cache,cdcache)
+    dv .-= dv_tmp
+
+    # Calculate the double-layer term
+    prescribed_surface_jump!(dvb,t,sys)
+    surface_divergence_symm!(dv_tmp,over_Re*dvb,base_cache)
+    dv .-= dv_tmp
+
+    # Apply forcing
+    apply_forcing!(dv_tmp,v,t,fcache,phys_params)
+    dv .+= dv_tmp
+
+    return dv
+end
+
+
+function viscousflow_vorticity_bc_rhs!(vb,sys::ILMSystem,t)
+    @unpack bc, forcing,extra_cache, base_cache, phys_params = sys
+    @unpack dvb, vb_tmp, v_tmp, velcache, divv_tmp = extra_cache
+    @unpack dcache, ϕtemp = velcache
+
+    viscousflow_velocity_bc_rhs!(vb,sys,t)
+
+    # Subtract influence of scalar potential field
+    fill!(divv_tmp,0.0)
+    prescribed_surface_jump!(dvb,t,sys)
+    scalarpotential_from_masked_divv!(ϕtemp,divv_tmp,dvb,base_cache,dcache)
+    vecfield_from_scalarpotential!(v_tmp,ϕtemp,base_cache)
+    interpolate!(vb_tmp,v_tmp,base_cache)
+    vb .-= vb_tmp
+
+    # Subtract influence of free stream
+    Uinf, Vinf = forcing["freestream"](t,phys_params)
+    vb.u .-= Uinf
+    vb.v .-= Vinf
+
+    return vb
+end
+
+function viscousflow_velocity_bc_rhs!(vb,sys::ILMSystem,t)
+    @unpack bc, forcing,extra_cache, base_cache, phys_params = sys
+    prescribed_surface_average!(vb,t,sys)
+    return vb
+end
+
+function viscousflow_vorticity_constraint_force!(dw,τ,sys)
+    @unpack extra_cache, base_cache = sys
+    @unpack dv = extra_cache
+
+    viscousflow_velocity_constraint_force!(dv,τ,sys)
+    curl!(dw,dv,base_cache)
+
+    return dw
+end
+
+function viscousflow_velocity_constraint_force!(dv,τ,sys::ILMSystem{S,P,N}) where {S,P,N}
+    @unpack base_cache = sys
+    regularize!(dv,τ,base_cache)
+    return dv
+end
+
+function viscousflow_velocity_constraint_force!(dv,τ,sys::ILMSystem{S,P,0}) where {S,P}
+    return dv
+end
+
+function viscousflow_vorticity_bc_op!(vb,w,sys::ILMSystem)
+    @unpack extra_cache, base_cache = sys
+    @unpack velcache, v_tmp = extra_cache
+    @unpack ψtemp = velcache
+
+    vectorpotential_from_curlv!(ψtemp,w,base_cache)
+    vecfield_from_vectorpotential!(v_tmp,ψtemp,base_cache)
+    viscousflow_velocity_bc_op!(vb,v_tmp,sys)
+
+    return vb
+end
+
+function viscousflow_velocity_bc_op!(vb,v,sys::ILMSystem)
+    @unpack base_cache = sys
+    interpolate!(vb,v,base_cache)
+    return vb
+end
+
+#= Support functions =#
+
+#=
+function surface_fluid_velocity_jump!(dvb,t,base_cache::BasicILMCache{N},bc,phys_params) where N
+    dvb .= bc["vbplus"](t,base_cache,phys_params)
+    dvb .-= bc["vbminus"](t,base_cache,phys_params)
+    return dvb
+end
+
+function surface_fluid_velocity_jump!(dvb,t,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(dvb,0.0)
+    return dvb
+end
+
+function surface_fluid_velocity_average!(vb,t,base_cache::BasicILMCache{N},bc,phys_params) where N
+    vb .= 0.5*bc["vbplus"](t,base_cache,phys_params)
+    vb .+= 0.5*bc["vbminus"](t,base_cache,phys_params)
+    return vb
+end
+
+function surface_fluid_velocity_average!(vb,t,base_cache::BasicILMCache{0},bc,phys_params)
+    fill!(vb,0.0)
+    return vb
+end
+=#
+
+
+#= Fields =#
+
+vorticity!(masked_w::Nodes{Dual},w::Nodes{Dual},dv::VectorData,base_cache::BasicILMCache,wcache::VectorPotentialCache) =
+            masked_curlv_from_curlv_masked!(masked_w,w,dv,base_cache,wcache)
+
+total_vorticity!(w::Nodes{Dual},masked_w::Nodes{Dual},dv::VectorData,base_cache::BasicILMCache,wcache::VectorPotentialCache) =
+            curlv_masked_from_masked_curlv!(w,masked_w,dv,base_cache,wcache)
+
+for f in [:vorticity,:total_vorticity]
+
+    f! = Symbol(string(f)*"!")
+
+    @eval function $f!(masked_w::Nodes{Dual},w::Nodes{Dual},sys::ILMSystem,t)
+        @unpack bc, forcing, phys_params, extra_cache, base_cache = sys
+        @unpack dvb, velcache = extra_cache
+        @unpack wcache = velcache
+
+        prescribed_surface_jump!(dvb,t,sys)
+
+        $f!(masked_w,w,dvb,base_cache,wcache)
+    end
+
+    @eval $f(w::Nodes{Dual},sys::ILMSystem,t) = $f!(zeros_gridcurl(sys),w,sys,t)
+
+    @eval $f(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t) = $f(state(u),sys,t)
+
+    @eval @snapshotoutput $f
+end
+
+function velocity!(v::Edges{Primal},curl_vmasked::Nodes{Dual},masked_divv::Nodes{Primal},dv::VectorData,vp,base_cache::BasicILMCache,velcache::VectorFieldCache,w_tmp::Nodes{Dual})
+    @unpack wcache, dcache  = velcache
+
+    masked_curlv = w_tmp
+
+    masked_curlv_from_curlv_masked!(masked_curlv,curl_vmasked,dv,base_cache,wcache)
+    vecfield_helmholtz!(v,masked_curlv,masked_divv,dv,vp,base_cache,velcache)
+
+    return v
+end
+
+function velocity!(v::Edges{Primal},w::Nodes{Dual},sys::ILMSystem,t)
+    @unpack bc, forcing, phys_params, extra_cache, base_cache = sys
+    @unpack dvb, velcache, divv_tmp, w_tmp = extra_cache
+
+    prescribed_surface_jump!(dvb,t,base_cache,bc,phys_params)
+
+    Vinf = forcing["freestream"](t,phys_params)
+
+    fill!(divv_tmp,0.0)
+    velocity!(v,w,divv_tmp,dvb,Vinf,base_cache,velcache,w_tmp)
+end
+
+velocity(w::Nodes{Dual},sys::ILMSystem,t) = velocity!(zeros_grid(sys),w,sys,t)
+
+velocity(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t) = velocity(state(u),sys,t)
+
+@snapshotoutput velocity
+
+
+function streamfunction!(ψ::Nodes{Dual},w::Nodes{Dual},vp::Tuple,base_cache::BasicILMCache,wcache::VectorPotentialCache)
+    @unpack stemp = wcache
+
+    fill!(ψ,0.0)
+    vectorpotential_from_curlv!(stemp,w,base_cache)
+    ψ .+= stemp
+
+    vectorpotential_uniformvecfield!(stemp,vp...,base_cache)
+    ψ .+= stemp
+
+    return ψ
+end
+
+function streamfunction!(ψ::Nodes{Dual},w::Nodes{Dual},sys::ILMSystem,t)
+    @unpack phys_params, forcing, extra_cache, base_cache = sys
+    @unpack velcache = extra_cache
+    @unpack wcache = velcache
+
+    Vinf = forcing["freestream"](t,phys_params)
+
+    streamfunction!(ψ,w,Vinf,base_cache,wcache)
+
+end
+
+streamfunction(w::Nodes{Dual},sys::ILMSystem,t) = streamfunction!(zeros_gridcurl(sys),w,sys,t)
+
+streamfunction(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t) = streamfunction(state(u),sys,t)
+
+@snapshotoutput streamfunction
+
+
+function scalarpotential!(ϕ::Nodes{Primal},divv::Nodes{Primal},vp::Tuple,base_cache::BasicILMCache,dcache::ScalarPotentialCache)
+    @unpack ftemp = dcache
+
+    fill!(ϕ,0.0)
+    scalarpotential_from_curlv!(ftemp,divv,base_cache)
+    ϕ .+= ftemp
+
+    scalarpotential_uniformvecfield!(ftemp,vp...,base_cache)
+    ϕ .+= ftemp
+
+    return ϕ
+end
+
+
+function scalarpotential!(ϕ::Nodes{Primal},divv::Nodes{Primal},sys::ILMSystem,t)
+    @unpack phys_params, forcing, extra_cache, base_cache = sys
+    @unpack velcache = extra_cache
+    @unpack dcache = velcache
+
+    Vinf = forcing["freestream"](t,phys_params)
+
+    scalarpotential!(ϕ,divv,Vinf,base_cache,dcache)
+
+end
+
+scalarpotential(divv::Nodes{Primal},sys::ILMSystem,t) = scalarpotential!(zeros_griddiv(sys),divv,sys,t)
+
+scalarpotential(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t) = scalarpotential(zeros_griddiv(sys),sys,t)
+
+@snapshotoutput scalarpotential
+
+
+function pressure!(press::Nodes{Primal},u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t)
+    @unpack extra_cache, base_cache = sys
+    @unpack velcache, v_tmp, dv_tmp, dv, divv_tmp = extra_cache
+
+    w, τ = state(u), constraint(u)
+    velocity!(v_tmp,w,sys,t)
+
+    viscousflow_velocity_ode_rhs!(dv,v_tmp,sys,t)
+
+
+    viscousflow_velocity_constraint_force!(dv_tmp,τ,sys)
+    dv .-= dv_tmp
+
+    divergence!(divv_tmp,dv,base_cache)
+    inverse_laplacian!(press,divv_tmp,base_cache)
+    return press
+end
+
+pressure(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem,t) = pressure!(zeros_griddiv(sys),u,sys,t)
+
+@snapshotoutput pressure
+
+#= Surface fields =#
+
+function traction!(tract::VectorData{N},τ::VectorData{N},sys::ILMSystem,t) where {N}
+    @unpack bc, extra_cache, base_cache, phys_params = sys
+    @unpack vb_tmp, dvb = extra_cache
+    @unpack sscalar_cache = base_cache
+
+    prescribed_surface_average!(vb_tmp,t,sys)
+    surface_velocity!(dvb,sys,t)
+    vb_tmp .-= dvb
+
+    nrm = normals(sys)
+    pointwise_dot!(sscalar_cache,nrm,vb_tmp)
+    prescribed_surface_jump!(dvb,t,sys)
+    product!(tract,dvb,sscalar_cache)
+
+    tract .+= τ
+    return tract
+
+end
+traction(τ::VectorData,sys::ILMSystem,t) = traction!(zeros_surface(sys),τ,sys,t)
+
+
+function pressurejump!(dpb::ScalarData{N},τ::VectorData{N},sys::ILMSystem,t) where {N}
+    @unpack base_cache = sys
+    @unpack sdata_cache = base_cache
+
+    nrm = normals(sys)
+    traction!(sdata_cache,τ,sys,t)
+    pointwise_dot!(dpb,nrm,sdata_cache)
+    dpb .*= -1.0
+    return dpb
+end
+pressurejump(τ::VectorData,sys::ILMSystem,t) = pressurejump!(zeros_surfacescalar(sys),τ,sys,t)
+
+
+for f in [:traction,:pressurejump]
+  f! = Symbol(string(f)*"!")
+  @eval $f!(out,τ::VectorData{0},sys::ILMSystem,t) = out
+
+  @eval $f(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem{S,P,N},t) where {S,P,N} = $f(constraint(u),sys,t)
+  @eval $f(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem{S,P,0},t) where {S,P} = $f(zeros_surface(sys),sys,t)
+
+  @eval @snapshotoutput $f
+
+end
+
+#= Integrated metrics =#
+
+force(τ,sys::ILMSystem{S,P,0},t,bodyi::Int) where {S,P} = Vector{Float64}(), Vector{Float64}()
+
+function force(τ::VectorData{N},sys::ILMSystem{S,P,N},t,bodyi::Int) where {S,P,N}
+    @unpack base_cache = sys
+    @unpack sdata_cache = base_cache
+    traction!(sdata_cache,τ,sys,t)
+    fx = integrate(sdata_cache.u,sys,bodyi)
+    fy = integrate(sdata_cache.v,sys,bodyi)
+
+    return fx, fy
+end
+
+function force(sol::ConstrainedSystems.OrdinaryDiffEq.ODESolution,sys::ILMSystem,bodyi::Int)
+    fx = map((u,t) -> force(u,sys,t,bodyi)[1],sol.u,sol.t)
+    fy = map((u,t) -> force(u,sys,t,bodyi)[2],sol.u,sol.t)
+    fx, fy
+end
+
+moment(τ,sys::ILMSystem{S,P,0},t,bodyi::Int;kwargs...) where {S,P} = Vector{Float64}()
+
+
+function moment(τ::VectorData{N},sys::ILMSystem{S,P,N},t,bodyi::Int;center=(0.0,0.0)) where {S,P,N}
+    @unpack base_cache = sys
+    @unpack sdata_cache, sscalar_cache = base_cache
+    xc, yc = center
+    pts = points(sys)
+    pts.u .-= xc
+    pts.v .-= yc
+
+    traction!(sdata_cache,τ,sys,t)
+    pointwise_cross!(sscalar_cache,pts,sdata_cache)
+    mom = integrate(sscalar_cache,sys,bodyi)
+
+    return mom
+end
+
+function moment(sol::ConstrainedSystems.OrdinaryDiffEq.ODESolution,sys::ILMSystem,bodyi::Int;kwargs...)
+    mom = map((u,t) -> moment(u,sys,t,bodyi;kwargs...),sol.u,sol.t)
+    mom
+end
+
+
+for f in [:force,:moment]
+
+    @eval $f(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem{S,P,N},t,bodyi) where {S,P,N} = $f(constraint(u),sys,t,bodyi)
+    @eval $f(u::ConstrainedSystems.ArrayPartition,sys::ILMSystem{S,P,0},t,bodyi) where {S,P} = $f(zeros_surface(sys),sys,t,bodyi)
+
+    @eval @snapshotoutput $f
+
+
+
+end

--- a/test/literate/neumann.jl
+++ b/test/literate/neumann.jl
@@ -110,11 +110,9 @@ function ImmersedLayers.solve(prob::NeumannPoissonProblem,sys::ILMSystem)
     df = zeros_surface(base_cache)
     ds = zeros_surface(base_cache)
 
-    vnplus = bc["vnplus function"](base_cache,phys_params)
-    vnminus = bc["vnminus function"](base_cache,phys_params)
-
-    vn .= 0.5*(vnplus+vnminus)
-    dvn .= vnplus - vnminus
+    ## Get the precribed jump and average of the surface normal derivatives
+    prescribed_surface_jump!(dvn,sys)
+    prescribed_surface_average!(vn,sys)
 
     ## Find the potential
     regularize!(fstar,dvn,base_cache)
@@ -173,7 +171,7 @@ function get_vnplus(base_cache,phys_params)
 end
 get_vnminus(base_cache,phys_params) = zeros_surface(base_cache)
 
-bcdict = Dict("vnplus function"=>get_vnplus,"vnminus function"=>get_vnminus)
+bcdict = Dict("exterior"=>get_vnplus,"interior"=>get_vnminus)
 
 
 #=
@@ -260,7 +258,7 @@ function get_vnminus(base_cache,phys_params)
     vnminus = zeros_surface(base_cache)
     return vnminus
 end
-bcdict = Dict("vnplus function"=>get_vnplus,"vnminus function"=>get_vnminus)
+bcdict = Dict("exterior"=>get_vnplus,"interior"=>get_vnminus)
 
 #=
 Create the problem and system

--- a/test/literate/stokes.jl
+++ b/test/literate/stokes.jl
@@ -105,11 +105,8 @@ function ImmersedLayers.solve(prob::StokesFlowProblem,sys::ILMSystem)
     s = zeros_gridcurl(sys)
     v = zeros_grid(sys)
 
-    vsplus = bc["vsplus function"](base_cache,phys_params)
-    vsminus = bc["vsminus function"](base_cache,phys_params)
-
-    dv .= vsplus-vsminus
-    vb .= 0.5*(vsplus + vsminus)
+    ## Get the jumps in velocity across surface
+    prescribed_surface_jump!(dv,sys)
 
     ## Compute ψ*
     surface_divergence_symm!(v,dv,sys)
@@ -124,6 +121,9 @@ function ImmersedLayers.solve(prob::StokesFlowProblem,sys::ILMSystem)
     regularize!(ϕ,dvn,Rc)
     inverse_laplacian!(ϕ,sys)
     grad!(vϕ,ϕ,sys)
+
+    ## Get the average velocity on the surface
+    prescribed_surface_average!(vb,sys)
     interpolate!(vprime,vϕ,sys)
     vprime .= vb - vprime
 
@@ -179,7 +179,7 @@ function get_vsplus(base_cache,phys_params)
 end
 get_vsminus(base_cache,phys_params) = zeros_surface(base_cache)
 
-bcdict = Dict("vsplus function"=>get_vsplus,"vsminus function"=>get_vsminus)
+bcdict = Dict("exterior"=>get_vsplus,"interior"=>get_vsminus)
 
 #=
 Set up the problem and the system, passing in the boundary condition information

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,8 @@ end
 if GROUP == "Notebooks"
   for (root, dirs, files) in walkdir(litdir)
     for file in files
-      #endswith(file,".jl") && startswith(file,"surfaceops") && Literate.notebook(joinpath(root, file),notebookdir)
-      endswith(file,".jl") && Literate.notebook(joinpath(root, file),notebookdir)
+      endswith(file,".jl") && startswith(file,"heatconduction.jl") && Literate.notebook(joinpath(root, file),notebookdir)
+      #endswith(file,".jl") && Literate.notebook(joinpath(root, file),notebookdir)
     end
   end
 end


### PR DESCRIPTION
This PR introduces the `prescribed_surface_jump!` and `prescribed_surface_average!` functions, which evaluate the functions supplied by the user in a Dict supplied to the system constructor by the `bc = ` keyword.