### PR TITLE
Change defaults

### DIFF
--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -59,7 +59,21 @@ export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
         solve, @snapshotoutput,@scalarsurfacemetric,@vectorsurfacemetric,
         prescribed_surface_jump!,prescribed_surface_average!
 
+
+abstract type AbstractBasicCache{N,GCT} end
+
+
+abstract type AbstractScalingType end
+
+abstract type GridScaling <: AbstractScalingType end
+abstract type IndexScaling <: AbstractScalingType end
+
 abstract type LayerType{N} end
+
+const DEFAULT_SCALING = GridScaling
+const DEFAULT_DATA_TYPE = Float64
+const DEFAULT_DDF = CartesianGrids.Yang3
+
 
 """
 $(TYPEDEF)

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,12 +1,4 @@
 
-abstract type AbstractBasicCache{N,GCT} end
-
-
-abstract type AbstractScalingType end
-
-abstract type GridScaling <: AbstractScalingType end
-abstract type IndexScaling <: AbstractScalingType end
-
 """
 $(TYPEDEF)
 
@@ -121,7 +113,7 @@ See [`SurfaceScalarCache`](@ref) for details.
 """ SurfaceVectorCache(::PhysicalGrid)
 
 """
-    SurfaceVectorCache(body::Body/BodyList,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=IndexScaling])
+    SurfaceVectorCache(body::Body/BodyList,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=Gridcaling])
 
 Create a cache of type `BasicILMCache`, holding operators and storage data
 for use in immersed layer operations on vector data. See [`SurfaceScalarCache`](@ref)
@@ -129,7 +121,7 @@ for details.
 """ SurfaceVectorCache(::Union{Body,BodyList},::PhysicalGrid)
 
 """
-    SurfaceScalarCache(body::Body/BodyList,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=IndexScaling])
+    SurfaceScalarCache(body::Body/BodyList,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=GridScaling])
 
 Create a cache of type `BasicILMCache`, holding operators and storage data
 for use in immersed layer operations on scalar data. This is sometimes called from within`ILMSystem` rather than directly.
@@ -145,7 +137,7 @@ be symmetric matrices (i.e., interpolation is the adjoint of regularization with
 """ SurfaceScalarCache(::Union{Body,BodyList},::PhysicalGrid)
 
 """
-    SurfaceScalarCache(X::VectorData,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=IndexScaling])
+    SurfaceScalarCache(X::VectorData,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=GridScaling])
 
 Create a cache of type `BasicILMCache`, holding operators and storage data
 for use in immersed layer operations on scalar data. The `X` specifies the
@@ -153,7 +145,7 @@ is assumed to hold the endpoints of the immersed surface segments, and `g` the p
 """ SurfaceScalarCache(::VectorData,::ScalarData,::VectorData,::PhysicalGrid)
 
 """
-    SurfaceVectorCache(X::VectorData,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=IndexScaling])
+    SurfaceVectorCache(X::VectorData,g::PhysicalGrid[,ddftype=CartesianGrids.Yang3][,scaling=GridScaling])
 
 Create a cache of type `BasicILMCache`, holding operators and storage data
 for use in immersed layer operations on vector data. See [`SurfaceScalarCache`](@ref)
@@ -163,9 +155,9 @@ for details.
 
 
 function SurfaceScalarCache(bl::BodyList,a::ScalarData{N},nrm::VectorData{N},g::PhysicalGrid;
-                              ddftype = CartesianGrids.Yang3,
-                              scaling = IndexScaling,
-                              dtype = Float64) where {N}
+                              ddftype = DEFAULT_DDF,
+                              scaling = DEFAULT_SCALING,
+                              dtype = DEFAULT_DATA_TYPE) where {N}
 
 	X = points(bl)
   sscalar_cache = nothing
@@ -182,9 +174,9 @@ function SurfaceScalarCache(bl::BodyList,a::ScalarData{N},nrm::VectorData{N},g::
 end
 
 function SurfaceVectorCache(bl::BodyList,a::ScalarData{N},nrm::VectorData{N},g::PhysicalGrid;
-                              ddftype = CartesianGrids.Yang3,
-                              scaling = IndexScaling,
-                              dtype = Float64) where {N}
+                              ddftype = DEFAULT_DDF,
+                              scaling = DEFAULT_SCALING,
+                              dtype = DEFAULT_DATA_TYPE) where {N}
 
 	X = points(bl)
   sscalar_cache = ScalarData(X, dtype = dtype)
@@ -271,13 +263,13 @@ struct PointCollectionCache{N,GCT,ND,PT,REGT<:Regularize,SST} <: AbstractBasicCa
     sdata_cache :: SST
 end
 
-function ScalarPointCollectionCache(X::VectorData{N},g::PhysicalGrid{ND};ddftype = CartesianGrids.Yang3,dtype = Float64) where {N,ND}
+function ScalarPointCollectionCache(X::VectorData{N},g::PhysicalGrid{ND};ddftype = DEFAULT_DDF,dtype = DEFAULT_DATA_TYPE) where {N,ND}
     gdata_cache = Nodes(Primal,size(g),dtype = dtype)
     sdata_cache = ScalarData(X,dtype = dtype)
     return _pointcollectioncache(X,g,gdata_cache,sdata_cache,ddftype)
 end
 
-function VectorPointCollectionCache(X::VectorData{N},g::PhysicalGrid{ND};ddftype = CartesianGrids.Yang3,dtype = Float64) where {N,ND}
+function VectorPointCollectionCache(X::VectorData{N},g::PhysicalGrid{ND};ddftype = DEFAULT_DDF,dtype = DEFAULT_DATA_TYPE) where {N,ND}
     gdata_cache = Edges(Primal,size(g),dtype = dtype)
     sdata_cache = VectorData(X,dtype = dtype)
     return _pointcollectioncache(X,g,gdata_cache,sdata_cache,ddftype)

--- a/src/forcing.jl
+++ b/src/forcing.jl
@@ -185,11 +185,15 @@ Assembly of the forcing model and forcing region
     ForcingModelAndRegion
 
 A type that holds the forcing model function, region, and cache
-# Constructor
+# Constructors
 
 `ForcingModelAndRegion(model::AbstractForcingModel,cache::BasicILMCache)`
 
-This form gets called generally when building the extra cache.
+`ForcingModelAndRegion(modellist::Vector{AbstractForcingModel},cache::BasicILMCache)`
+
+These forms gets called generally when building the extra cache. They
+also gracefully generate an empty list of models if one passes along `nothing`
+in the first argument. 
 """ ForcingModelAndRegion(::AbstractForcingModel,::BasicILMCache)
 
 struct ForcingModelAndRegion{RT<:AbstractRegionCache,ST,MT,KT}
@@ -215,6 +219,8 @@ function ForcingModelAndRegion(flist::Vector{<:AbstractForcingModel},cache::Basi
    end
    return fmlist
 end
+
+ForcingModelAndRegion(::Nothing,cache::BasicILMCache) = ForcingModelAndRegion(AbstractForcingModel[],cache)
 
 #=
 Application of forcing

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -1,5 +1,6 @@
 abstract type AbstractILMProblem{DT,ST,DTP} end
 
+
 function regenerate_problem() end
 
 """
@@ -30,7 +31,7 @@ resulting type then automatically has a constructor that allows one to pass
 in the grid information and bodies, as well as optional choices for the
 DDF function and the scaling type. For the example, this constructor would be
 
-    StokesFlowProblem(grid,bodies[,ddftype=CartesianGrids.Yang3][,scaling=IndexScaling])
+    StokesFlowProblem(grid,bodies[,ddftype=CartesianGrids.Yang3][,scaling=GridScaling])
 
 Note that there is another constructor for problems with no surfaces that only
 requires that the grid information be passed, e.g.,
@@ -72,9 +73,9 @@ macro ilmproblem(name,vector_or_scalar)
              forcing :: FF
              timestep_func :: DTF
              motions :: MTF
-             $typename(g::PT,bodies::BodyList;ddftype=CartesianGrids.Yang3,
-                                              scaling=IndexScaling,
-                                              dtype=Float64,
+             $typename(g::PT,bodies::BodyList;ddftype=ImmersedLayers.DEFAULT_DDF,
+                                              scaling=ImmersedLayers.DEFAULT_SCALING,
+                                              dtype=ImmersedLayers.DEFAULT_DATA_TYPE,
                                               phys_params=nothing,
                                               bc=nothing,
                                               forcing=nothing,


### PR DESCRIPTION
This PR sets uniform default values for several of the keywords in problem construction. It also ensures that a blank forcing model is gracefully created when a null argument is supplied.