### PR TITLE
Use AbstractSpatialFields in forcing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
+SpaceTimeFields = "0af78db0-3b7c-4df8-88bd-686b7cc5245d"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
@@ -25,6 +26,7 @@ DocStringExtensions = "0.8.4"
 RecipesBase = "1.0"
 Reexport = "0.2.0, 1"
 RigidBodyTools = "0.3.2"
+SpaceTimeFields = "0.1.1"
 UnPack = "1.0.2"
 julia = "1.4"
 

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -9,6 +9,7 @@ using DocStringExtensions
 @reexport using CartesianGrids
 @reexport using RigidBodyTools
 @reexport using ConstrainedSystems
+#@reexport using SpaceTimeFields
 
 import CartesianGrids: Laplacian
 

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -434,11 +434,17 @@ end
    @test_throws DimensionMismatch apply_forcing!(dT2,T2,t,fcache2,phys_params)
 
    # Area forcing with no shape mask
-   function model2!(σ,T,t,fr::AreaRegionCache,phys_params)
-       σ .= phys_params["areaheater1_flux"]
-    end
-    afm = AreaForcingModel(model2!)
+    afm = AreaForcingModel(model1!)
     fcache = ForcingModelAndRegion(afm,scache)
     apply_forcing!(dT,T,t,fcache,phys_params)
+
+    function model6!(σ,T,t,fr::AreaRegionCache,phys_params)
+        σ .= fr.generated_field()
+     end
+    afm = AreaForcingModel(model6!,spatialfield=SpatialGaussian(0.5,0.1,0,0,10))
+    fcache = ForcingModelAndRegion(afm,scache)
+    apply_forcing!(dT,T,t,fcache,phys_params)
+
+    @test dT == fcache.region_cache.generated_field()
 
 end

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -433,4 +433,12 @@ end
 
    @test_throws DimensionMismatch apply_forcing!(dT2,T2,t,fcache2,phys_params)
 
+   # Area forcing with no shape mask
+   function model2!(σ,T,t,fr::AreaRegionCache,phys_params)
+       σ .= phys_params["areaheater1_flux"]
+    end
+    afm = AreaForcingModel(model2!)
+    fcache = ForcingModelAndRegion(afm,scache)
+    apply_forcing!(dT,T,t,fcache,phys_params)
+
 end


### PR DESCRIPTION
This PR allows area type forcing to use `AbstractSpatialFields` (from the `CartesianGrids.jl` package) for creating the forcing strength. It also allows the special case of area-type forcing with no mask (i.e., filling all space).