### PR TITLE
Allow function names to be more flexible

### DIFF
--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -95,7 +95,7 @@ mutable struct ILMSystem{static,PT,N,PHT,BCF,FF,DTF,MTF,BCT,ECT}
 
 end
 
-_get_function_name(f::Function) = f
+_get_function_name(f) = f
 _get_function_name(f::Symbol) = eval(f)
 
 

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -95,6 +95,10 @@ mutable struct ILMSystem{static,PT,N,PHT,BCF,FF,DTF,MTF,BCT,ECT}
 
 end
 
+_get_function_name(f::Function) = f
+_get_function_name(f::Symbol) = eval(f)
+
+
 include("cartesian_extensions.jl")
 include("tools.jl")
 include("cache.jl")

--- a/src/bc.jl
+++ b/src/bc.jl
@@ -12,14 +12,14 @@ for f in [:prescribed_surface_jump!,:prescribed_surface_average!]
 end
 
 function prescribed_surface_jump!(dfb,t::Real,base_cache::BasicILMCache{N},bc,phys_params,motions) where N
-    dfb .= bc["exterior"](t,base_cache,phys_params,motions)
-    dfb .-= bc["interior"](t,base_cache,phys_params,motions)
+    dfb .= _get_function_name(bc["exterior"])(t,base_cache,phys_params,motions)
+    dfb .-= _get_function_name(bc["interior"])(t,base_cache,phys_params,motions)
     return dfb
 end
 
 function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{N},bc,phys_params) where N
-    dfb .= bc["exterior"](base_cache,phys_params)
-    dfb .-= bc["interior"](base_cache,phys_params)
+    dfb .= _get_function_name(bc["exterior"])(base_cache,phys_params)
+    dfb .-= _get_function_name(bc["interior"])(base_cache,phys_params)
     return dfb
 end
 
@@ -34,8 +34,8 @@ function prescribed_surface_jump!(dfb,base_cache::BasicILMCache{0},bc,phys_param
 end
 
 function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{N},bc,phys_params,motions) where N
-    fb .= 0.5*bc["exterior"](t,base_cache,phys_params,motions)
-    fb .+= 0.5*bc["interior"](t,base_cache,phys_params,motions)
+    fb .= 0.5*_get_function_name(bc["exterior"])(t,base_cache,phys_params,motions)
+    fb .+= 0.5*_get_function_name(bc["interior"])(t,base_cache,phys_params,motions)
     return fb
 end
 
@@ -45,8 +45,8 @@ function prescribed_surface_average!(fb,t::Real,base_cache::BasicILMCache{0},bc,
 end
 
 function prescribed_surface_average!(fb,base_cache::BasicILMCache{N},bc,phys_params) where N
-    fb .= 0.5*bc["exterior"](base_cache,phys_params)
-    fb .+= 0.5*bc["interior"](base_cache,phys_params)
+    fb .= 0.5*_get_function_name(bc["exterior"])(base_cache,phys_params)
+    fb .+= 0.5*_get_function_name(bc["interior"])(base_cache,phys_params)
     return fb
 end
 

--- a/src/timemarching.jl
+++ b/src/timemarching.jl
@@ -208,6 +208,6 @@ function init(u0,tspan,sys::ILMSystem;alg=ConstrainedSystems.LiskaIFHERK(),kwarg
     fode = ConstrainedODEFunction(sys)
 
     prob = ODEProblem(fode,u0,tspan,sys)
-    dt_calc = timestep_func(sys)
+    dt_calc = _get_function_name(timestep_func(sys))
     return init(prob, alg,dt=dt_calc,internalnorm=state_norm,kwargs...)
 end


### PR DESCRIPTION
Allow function names in Dicts to be either the literal name or a symbol. (Symbol is preferred, but this allows legacy). The purpose of this is to ensure that the `ILMSystem` structure can be written to file