### PR TITLE
Extend spatial fields

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CartesianGrids = "0.1.22"
+CartesianGrids = "0.1.25"
 CatViews = "1.0.0"
 ColorTypes = "<0.10.1, 0.10, 0.11"
 ConstrainedSystems = "0.2.5"

--- a/docs/src/manual/caches.md
+++ b/docs/src/manual/caches.md
@@ -198,6 +198,7 @@ x_griddiv
 y_griddiv
 x_gridgrad
 y_gridgrad
+evaluate_field!
 ```
 
 ## Utilities for accessing surface information

--- a/docs/src/manual/heatconduction-unbounded.md
+++ b/docs/src/manual/heatconduction-unbounded.md
@@ -198,7 +198,7 @@ function ImmersedLayers.prob_cache(prob::UnboundedHeatConductionProblem,
 
     # Construct a Lapacian outfitted with the diffusivity
     κ = phys_params["diffusivity"]
-    heat_L = Laplacian(base_cache,gdata_cache,κ)
+    heat_L = Laplacian(base_cache,κ)
 
     # Create cache for the convective derivative
     v = zeros_gridgrad(base_cache)

--- a/docs/src/manual/heatconduction.md
+++ b/docs/src/manual/heatconduction.md
@@ -159,7 +159,7 @@ function ImmersedLayers.prob_cache(prob::DirichletHeatConductionProblem,
 
     # Construct a Lapacian outfitted with the diffusivity
     κ = phys_params["diffusivity"]
-    heat_L = Laplacian(base_cache,gdata_cache,κ)
+    heat_L = Laplacian(base_cache,κ)
 
     # State (grid temperature data) and constraint (surface Lagrange multipliers)
     f = ODEFunctionList(state = zeros_grid(base_cache),

--- a/src/ImmersedLayers.jl
+++ b/src/ImmersedLayers.jl
@@ -27,7 +27,7 @@ export DoubleLayer, SingleLayer, MaskType, Mask, ComplementaryMask,
         BasicScalarILMProblem,BasicVectorILMProblem,prob_cache,
         AbstractScalingType,GridScaling,IndexScaling,
         BasicILMCache,ILMSystem,
-        ODEFunctionList,zeros_sol,init_sol,
+        ODEFunctionList,zeros_sol,init_sol,evaluate_field!,
         get_grid,get_bodies,
         similar_grid,similar_gridgrad,similar_gridcurl,similar_griddiv,similar_gridgradcurl,
         similar_surface,similar_surfacescalar,
@@ -106,6 +106,7 @@ include("tools.jl")
 include("cache.jl")
 include("problem.jl")
 include("system.jl")
+include("fields.jl")
 include("layers.jl")
 include("grid_operators.jl")
 include("surface_operators.jl")
@@ -115,6 +116,7 @@ include("helmholtz.jl")
 include("timemarching.jl")
 include("output.jl")
 include("bc.jl")
+
 
 include("plot_recipes.jl")
 

--- a/src/fields.jl
+++ b/src/fields.jl
@@ -1,0 +1,28 @@
+# Routines for creating instances of spatial fields on the grid
+
+"""
+    evaluate_field!(f::GridData,s::AbstractSpatialField,cache)
+
+Evaluate a spatial field `s` in place as grid data `f`.
+"""
+function evaluate_field!(f::GridData,s::AbstractSpatialField,cache::BasicILMCache)
+    @unpack g = cache
+    gf = GeneratedField(f,s,g)
+    f .= gf()
+    return f
+end
+
+"""
+    evaluate_field!(f::GridData,t,s::AbstractSpatialField,cache)
+
+Evaluate a spatial-temporal field `s` at time `t` in place as grid data `f`.
+"""
+function evaluate_field!(f::GridData,t,s::AbstractSpatialField,cache::BasicILMCache)
+    @unpack g = cache
+    gf = GeneratedField(f,s,g)
+    f .= gf(t)
+    return f
+end
+
+evaluate_field!(f::GridData,s::AbstractSpatialField,sys::ILMSystem) = evaluate_field!(f,s,sys.base_cache)
+evaluate_field!(f::GridData,t,s::AbstractSpatialField,sys::ILMSystem) = evaluate_field!(f,t,s,sys.base_cache)

--- a/src/timemarching.jl
+++ b/src/timemarching.jl
@@ -143,8 +143,7 @@ function init_sol(s::AbstractSpatialField,sys::ILMSystem)
     @unpack g = base_cache
     sol = zeros_sol(sys)
     _initialize_motion!(sol,sys)
-    gf = GeneratedField(state(sol),s,g)
-    state(sol) .= gf()
+    evaluate_field!(state(sol),s,sys)
     return sol
 end
 

--- a/test/literate/caches.jl
+++ b/test/literate/caches.jl
@@ -185,6 +185,7 @@ dot(os,os,cache)
 #md # y_griddiv
 #md # x_gridgrad
 #md # y_gridgrad
+#md # evaluate_field!
 #md # ```
 
 #md # ## Utilities for accessing surface information

--- a/test/surface_ops.jl
+++ b/test/surface_ops.jl
@@ -30,6 +30,18 @@ _size(::CartesianGrids.Laplacian{NX,NY}) where {NX,NY} = NX, NY
   @test size(g) == _size(scache1.L)
 end
 
+@testset "Fields" begin
+  scache1 = SurfaceScalarCache(g,scaling=GridScaling)
+  myfun(x,y) = exp(-x)*exp(-y)
+  field = SpatialField(myfun)
+  evaluate_field!(w,field,scache1)
+  xc, yc = coordinates(w,g)
+
+  @test w[104,24] ≈ myfun(xc[24],yc[104])
+
+end
+
+
 @testset "Scalar surface ops" begin
   scache = SurfaceScalarCache(body,g,scaling=GridScaling)
 

--- a/test/tools.jl
+++ b/test/tools.jl
@@ -34,7 +34,10 @@ os .= 1
    @test_throws MethodError dot(w,u,g)
    @test_throws AssertionError dot(u,u,g)
 
-   @test norm(w,g) == sqrt((xlim[2]-xlim[1])*(ylim[2]-ylim[1]))
+   new_xlim = limits(g,1)
+   new_ylim = limits(g,2)
+
+   @test norm(w,g) == sqrt((new_xlim[2]-new_xlim[1])*(new_ylim[2]-new_ylim[1]))
 
    @test isapprox(dot(os,os,ds),2π,atol=1e-3)
 


### PR DESCRIPTION
This PR allows easy creation and evaluation of spatial and spatial-temporal fields on grid data. For example,

```
g = PhysicalGrid((-2,2),(-2,2),0.02)
cache = SurfaceVectorCache(g)
f = zeros_gridcurl(cache)

myfun(x,y,t) = exp(-x)*exp(-y)
sfield = SpatialField(myfun)
evaluate_field!(f,sfield,cache)

myfun2(x,y,t) = exp(-x)*exp(-y)*cos(t)
stfield = SpatialTemporalField(myfun2)
t = 1.0
evaluate_field!(f,t,stfield,cache)
```