### PR TITLE
[WIP] Faster `update_system` calls

### DIFF
--- a/src/cache.jl
+++ b/src/cache.jl
@@ -387,7 +387,7 @@ _ddf_type(R::Regularize) = _ddf_type(R.ddf)
 _ddf_type(cache::BasicILMCache) = _ddf_type(cache.regop)
 
 # Getting the list of first indices for each body, for partitioning of surface vectors
-_firstindices(b::Body) = [1,length(body)+1]
+_firstindices(b::Body) = [1,length(b)+1]
 _firstindices(bl::BodyList) = [map(i -> first(getrange(bl,i)),1:length(bl)); numpts(bl)+1]
 
 ## Obtaining copies of the grid and surface data

--- a/src/system.jl
+++ b/src/system.jl
@@ -25,7 +25,7 @@ the Body or BodyList `body`.
 """
 function update_system(sysold::ILMSystem,body::Union{Body,BodyList})
     prob = regenerate_problem(sysold,body)
-    return __init(prob)
+    return __init(prob;L=sysold.base_cache.L)
 end
 
 """
@@ -55,11 +55,11 @@ Initialize `ILMSystem` with the given problem `prob` specification.
 Depending on the type of problem, this sets up a base cache of scalar or
 vector type, as well as an optional extra cache
 =#
-function __init(prob::AbstractILMProblem{DT,ST,DTP}) where {DT,ST,DTP}
+function __init(prob::AbstractILMProblem{DT,ST,DTP};kwargs...) where {DT,ST,DTP}
     @unpack g, bodies, phys_params, bc, forcing, timestep_func, motions = prob
     @unpack m, reference_body = motions
 
-    base_cache = _construct_base_cache(bodies,g,DT,ST,DTP,prob,Val(length(bodies)))
+    base_cache = _construct_base_cache(bodies,g,DT,ST,DTP,prob,Val(length(bodies));kwargs...)
 
     extra_cache = prob_cache(prob,base_cache)
 
@@ -69,17 +69,17 @@ function __init(prob::AbstractILMProblem{DT,ST,DTP}) where {DT,ST,DTP}
 
 end
 
-@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{0}) where {PT <: AbstractScalarILMProblem} =
-              SurfaceScalarCache(g,ddftype=DT,scaling=ST,dtype=DTP)
+@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{0};kwargs...) where {PT <: AbstractScalarILMProblem} =
+              SurfaceScalarCache(g;ddftype=DT,scaling=ST,dtype=DTP,kwargs...)
 
-@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{N}) where {PT <: AbstractScalarILMProblem,N} =
-              SurfaceScalarCache(bodies,g,ddftype=DT,scaling=ST,dtype=DTP)
+@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{N};kwargs...) where {PT <: AbstractScalarILMProblem,N} =
+              SurfaceScalarCache(bodies,g;ddftype=DT,scaling=ST,dtype=DTP,kwargs...)
 
-@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{0}) where {PT <: AbstractVectorILMProblem} =
-              SurfaceVectorCache(g,ddftype=DT,scaling=ST,dtype=DTP)
+@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{0};kwargs...) where {PT <: AbstractVectorILMProblem} =
+              SurfaceVectorCache(g;ddftype=DT,scaling=ST,dtype=DTP,kwargs...)
 
-@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{N}) where {PT <: AbstractVectorILMProblem,N} =
-              SurfaceVectorCache(bodies,g,ddftype=DT,scaling=ST,dtype=DTP)
+@inline _construct_base_cache(bodies,g,DT,ST,DTP,::PT,::Val{N};kwargs...) where {PT <: AbstractVectorILMProblem,N} =
+              SurfaceVectorCache(bodies,g;ddftype=DT,scaling=ST,dtype=DTP,kwargs...)
 
 isstatic(::ILMSystem{ST}) where {ST} = ST
 


### PR DESCRIPTION
This PR adds `kwargs...` to `__init` and `construct_base_cache`, such that `update_system` can reuse the old system's Laplacian. This avoids some expensive `plan_laplacian` calls.

I'm not sure if it is desirable that `update_system` always keeps the old Laplacian operator. If not, these changes will have to be implemented differently.

Also, the `kwargs` argument in `construct_base_cache` will only be passed to the constructor of the `base_cache` and not the `prob_cache`. I'm not sure if this is desirable either.