### PR TITLE
Allow use of CartesianGrids in v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ RigidBodyTools = "befc5f09-81d5-499c-a4b2-d0464ba9f9c8"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-CartesianGrids = "0.1.29"
+CartesianGrids = "0.1.29, 0.2"
 CatViews = "1.0.0"
 ColorTypes = "<0.10.1, 0.10, 0.11"
 ConstrainedSystems = "0.3.8"


### PR DESCRIPTION
This PR allows the package to use CartesianGrids.jl at v0.2.0, which has an improved optimization of grids and use of multithreading.